### PR TITLE
Replace snapshot id with url parameters

### DIFF
--- a/source/SnapDump-Client/SDClient.class.st
+++ b/source/SnapDump-Client/SDClient.class.st
@@ -30,6 +30,6 @@ SDClient >> projects [
 ]
 
 { #category : #searching }
-SDClient >> snapshotWithId: aString project: aProjectName version: aVersionName exceptionId: anExceptionId [
-	^ self store snapshotWithId: aString project: aProjectName version: aVersionName exceptionId: anExceptionId
+SDClient >> snapshotWithId: aString [ 
+	^ self store snapshotWithId: aString 
 ]

--- a/source/SnapDump-Client/SDClient.class.st
+++ b/source/SnapDump-Client/SDClient.class.st
@@ -30,6 +30,17 @@ SDClient >> projects [
 ]
 
 { #category : #searching }
-SDClient >> snapshotWithId: aString [ 
-	^ self store snapshotWithId: aString 
+SDClient >> snapshotWithId: aString project: aProjectString version: aVersionString [
+
+	| project version |
+	project := (self store  projectNamed: aProjectString).
+	version := (SDVersion string: aVersionString) project: project; yourself. 
+	^ (self store
+		snapshotWithId: aString
+		project: aProjectString
+		version: aVersionString)
+		initializeMetaFromFile;
+		project: project;
+		version: version;
+		yourself
 ]

--- a/source/SnapDump-Client/SDClient.class.st
+++ b/source/SnapDump-Client/SDClient.class.st
@@ -30,6 +30,6 @@ SDClient >> projects [
 ]
 
 { #category : #searching }
-SDClient >> snapshotWithId: aString [ 
-	^ self store snapshotWithId: aString 
+SDClient >> snapshotWithId: aString project: aProjectName version: aVersionName exceptionId: anExceptionId [
+	^ self store snapshotWithId: aString project: aProjectName version: aVersionName exceptionId: anExceptionId
 ]

--- a/source/SnapDump-Client/SDHTTPStore.class.st
+++ b/source/SnapDump-Client/SDHTTPStore.class.st
@@ -73,9 +73,9 @@ SDHTTPStore >> snapshotDumpWithId: aString [
 ]
 
 { #category : #'as yet unclassified' }
-SDHTTPStore >> snapshotWithId: aString [ 
+SDHTTPStore >> snapshotWithId: aString project: aProjectName version: aVersionName exceptionId: anExceptionId [
 	^ self client
-		url: uri / #snapshots / aString / #snap;
+		url: (self urlForSnapshot: aString project: aProjectName version: aVersionName exception: anExceptionId) / #snap;
 		get
 ]
 

--- a/source/SnapDump-Client/SDHTTPStore.class.st
+++ b/source/SnapDump-Client/SDHTTPStore.class.st
@@ -57,7 +57,7 @@ SDHTTPStore >> projects [
 SDHTTPStore >> removeSnapshot: aSnapshot [ 
 	| response |
 	response := self client
-		url: uri / #snapshots / aSnapshot id;
+		url: (self urlForSnapshot: aSnapshot);
 		delete;
 		response.
 	response isSuccess 
@@ -65,10 +65,10 @@ SDHTTPStore >> removeSnapshot: aSnapshot [
 ]
 
 { #category : #'as yet unclassified' }
-SDHTTPStore >> snapshotDumpWithId: aString [ 
+SDHTTPStore >> snapshotDumpFor: aSnapshot [ 
 	^ self client
 		headerAt: 'Accept' put: 'application/X-SnapDump-Fuel';
-		url: uri / #snapshots / aString;
+		url: (self urlForSnapshot: aSnapshot);
 		get
 ]
 
@@ -77,6 +77,20 @@ SDHTTPStore >> snapshotWithId: aString project: aProjectName version: aVersionNa
 	^ self client
 		url: (self urlForSnapshot: aString project: aProjectName version: aVersionName exception: anExceptionId) / #snap;
 		get
+]
+
+{ #category : #'as yet unclassified' }
+SDHTTPStore >> snapshotsWithProject: projectName version: versionString [
+	| response  |
+	
+	response := self client
+		url: uri / #projects / projectName urlEncoded / #versions / versionString urlEncoded  / #snapshots;
+		get;
+		response.
+	response isSuccess 
+		ifTrue: [  
+	^ ((NeoJSONReader on: response contents readStream) nextListAs: SDSnapshot) ]
+		ifFalse: [ NotFound signal ]
 ]
 
 { #category : #'as yet unclassified' }
@@ -98,7 +112,7 @@ SDHTTPStore >> snapshotsWithVersion: aVersion [
 SDHTTPStore >> versionsOfProject: aProject [ 
 	| response |
 	response := self client
-		url: uri / #projects / aProject name / #versions;
+		url: uri / #projects / aProject name urlEncoded / #versions;
 		get;
 		response.
 	response isSuccess 

--- a/source/SnapDump-Client/SDHTTPStore.class.st
+++ b/source/SnapDump-Client/SDHTTPStore.class.st
@@ -119,5 +119,5 @@ SDHTTPStore >> versionsOfProject: aProject [
 		ifTrue: [  
 			^ ((NeoJSONReader on: response contents readStream) nextListAs: SDVersion) do: [ :v |
 				v project: aProject ] ]
-		ifFalse: [ NotFound signal ]
+		ifFalse: [ NotFound signal: (aProject name , ' project not found') ]
 ]

--- a/source/SnapDump-Core-Tests/SDCoreTests.class.st
+++ b/source/SnapDump-Core-Tests/SDCoreTests.class.st
@@ -4,6 +4,12 @@ Class {
 	#category : #'SnapDump-Core-Tests'
 }
 
+{ #category : #tests }
+SDCoreTests >> getDummySnapshotFromClient [
+	^ client
+		snapshotWithId: self dummySnapshotId
+]
+
 { #category : #accessing }
 SDCoreTests >> store [ 
 	^ self filesystemStore
@@ -103,7 +109,7 @@ SDCoreTests >> testRemoveSnapshot [
 
 	|  snapshot |
 	self createSimpleSnapshot.
-	snapshot := client snapshotWithId: self dummySnapshotId.
+	snapshot := self getDummySnapshotFromClient.
 	self assert: snapshot className equals: 'Object'.
 	self 
 		shouldnt: [ snapshot remove ]
@@ -113,24 +119,28 @@ SDCoreTests >> testRemoveSnapshot [
 
 { #category : #tests }
 SDCoreTests >> testRemoveVersion [
-
-	|  snapshot |
+	| snapshot |
 	self createSimpleSnapshot.
-	snapshot := client snapshotWithId: self dummySnapshotId.
+	snapshot := self getDummySnapshotFromClient.
 	self assert: snapshot className equals: 'Object'.
 	snapshot version remove.
-	self assert: client projects isEmpty 
+	self assert: client projects isEmpty
 ]
 
 { #category : #tests }
 SDCoreTests >> testSetup [
-	| mock |
+	| mock root |
 	mock := self snapshotMock.
 	self 
 		shouldnt: [ handler handleException: mock ]
 		raise: Error.
-	self assert: rootPath hasFiles.
-	self assert: ((rootPath / mock asSnapshot id), #snap) exists.
+	"only directories should be contained by the root path"
+	self deny: rootPath hasFiles.
+	self assert: rootPath hasDirectories.
+	root := self dummySnapshotRootPath.
+	self assert: root exists. 
+	self assert: root isDirectory. 
+	self assert: ((root / mock asSnapshot snapshotId), #snap) exists.
 
 ]
 
@@ -139,6 +149,6 @@ SDCoreTests >> testSnapshot [
 
 	|  snapshot |
 	self createSimpleSnapshot.
-	snapshot := client snapshotWithId: self dummySnapshotId.
+	snapshot := self getDummySnapshotFromClient.
 	self assert: snapshot className equals: 'Object'
 ]

--- a/source/SnapDump-Core-Tests/SDCoreTests.class.st
+++ b/source/SnapDump-Core-Tests/SDCoreTests.class.st
@@ -7,7 +7,7 @@ Class {
 { #category : #tests }
 SDCoreTests >> getDummySnapshotFromClient [
 	^ client
-		snapshotWithId: self dummySnapshotId
+		snapshotWithId: self dummySnapshotId project: self projectNameForTests version: self versionStringForTests
 ]
 
 { #category : #accessing }

--- a/source/SnapDump-Core-Tests/SDHandler.extension.st
+++ b/source/SnapDump-Core-Tests/SDHandler.extension.st
@@ -13,8 +13,8 @@ SDHandler class >> fillExamples [
 		projectName: ('projectname', x asString) 
 		versionString: '1.', y asString.
 	snapshot := SDTests new dummyContext asSnapshot
-		project: handler project;
-		version: (handler version).
+		projectName: handler project;
+		versionString: (handler version).
 	"snapshot id: (snapshot id at: snapshot id size atRandom put: Character alphabet atRandom; yourself)".
 	handler handleSnapshot: snapshot ] ] ]
 ]

--- a/source/SnapDump-Core-Tests/SDTests.class.st
+++ b/source/SnapDump-Core-Tests/SDTests.class.st
@@ -39,8 +39,18 @@ SDTests >> dummyContext [
 ]
 
 { #category : #tests }
+SDTests >> dummyProjectName [
+	^ 'dummy-project'
+]
+
+{ #category : #tests }
 SDTests >> dummySnapshotId [
 	^ '292310505b9f7c1493d42c91693b6222e09f5ec6cd1e16d18d1b7ec1570d8a03'
+]
+
+{ #category : #tests }
+SDTests >> dummyVersionString [
+	^ '1.0'
 ]
 
 { #category : #running }

--- a/source/SnapDump-Core-Tests/SDTests.class.st
+++ b/source/SnapDump-Core-Tests/SDTests.class.st
@@ -59,7 +59,7 @@ SDTests >> dummySnapshotId [
 
 { #category : #tests }
 SDTests >> dummySnapshotRootPath [
-	^ rootPath / self projectNameForTests / self versionStringForTests
+	^ rootPath / self projectNameForTests / self versionStringForTests / self dummyExceptionId 
 	
 ]
 

--- a/source/SnapDump-Core-Tests/SDTests.class.st
+++ b/source/SnapDump-Core-Tests/SDTests.class.st
@@ -38,19 +38,29 @@ SDTests >> dummyContext [
 	^ context
 ]
 
-{ #category : #tests }
-SDTests >> dummyProjectName [
-	^ 'dummy-project'
+{ #category : #'as yet unclassified' }
+SDTests >> dummyContextSnapshot [
+	
+	^ self dummyContext asSnapshot 
+			instVarNamed: #exceptionId  put: self dummyExceptionId;
+			instVarNamed: #snapshotId  put: self dummySnapshotId;
+			yourself
 ]
 
 { #category : #tests }
-SDTests >> dummySnapshotId [
+SDTests >> dummyExceptionId [
 	^ '292310505b9f7c1493d42c91693b6222e09f5ec6cd1e16d18d1b7ec1570d8a03'
 ]
 
 { #category : #tests }
-SDTests >> dummyVersionString [
-	^ '1.0'
+SDTests >> dummySnapshotId [
+	^ 'a946512aec0333fecaa26fbb58131ffec168e43b8f8e56999603005c94e39c92'
+]
+
+{ #category : #tests }
+SDTests >> dummySnapshotRootPath [
+	^ rootPath / self projectNameForTests / self versionStringForTests
+	
 ]
 
 { #category : #running }
@@ -59,22 +69,28 @@ SDTests >> filesystemStore [
 ]
 
 { #category : #running }
-SDTests >> setUp [ 
+SDTests >> projectNameForTests [
+	^ 'TestProject'
+]
+
+{ #category : #running }
+SDTests >> setUp [
 	| store |
 	rootPath := FileSystem memory / #snaps.
 	store := self store.
-	handler := SDHandler new store: store. 
-	client := SDClient new store: store. 
-	handler 
-		projectName: 'TestProject'
-		versionString: '0.1'
+	handler := SDHandler new store: store.
+	client := SDClient new store: store.
+	handler
+		projectName: self projectNameForTests
+		versionString: self versionStringForTests
 ]
 
 { #category : #tests }
 SDTests >> snapshotMock [
 	| mock |
 	mock := Mock new. 
-	mock stub asSnapshot willReturn: self dummyContext asSnapshot.
+	mock stub asSnapshot  
+		willReturn: self dummyContextSnapshot.
 	^ mock
 
 ]
@@ -82,4 +98,9 @@ SDTests >> snapshotMock [
 { #category : #accessing }
 SDTests >> store [
 	self subclassResponsibility 
+]
+
+{ #category : #running }
+SDTests >> versionStringForTests [
+	^ '0.1'
 ]

--- a/source/SnapDump-Core/SDFileSnapshot.class.st
+++ b/source/SnapDump-Core/SDFileSnapshot.class.st
@@ -53,6 +53,12 @@ SDFileSnapshot >> initializeMeta: dictionary [
 		self instVarNamed: field put: (dictionary at: field) ]
 ]
 
+{ #category : #'as yet unclassified' }
+SDFileSnapshot >> initializeMetaFromFile [
+
+	self initializeMeta: (self class readMetaFrom: file asFileReference binaryReadStream)
+]
+
 { #category : #actions }
 SDFileSnapshot >> openDebugger [ 
 	FLMaterializer materializeFromByteArray: self contents
@@ -61,17 +67,6 @@ SDFileSnapshot >> openDebugger [
 { #category : #'instance creation' }
 SDFileSnapshot >> readFrom: aStream [
 	^ self setFuelHeader: (FLMaterializer new materializeHeaderFrom: aStream)
-]
-
-{ #category : #'as yet unclassified' }
-SDFileSnapshot >> sanitize [
-	"prevent project or version to be nil. If there is an error reported without
-	those fields it is better to store it with a default name so it can be seen
-	that the setup is wrong"
-	(project isNil or: [ project name isEmpty ]) ifTrue: [ 
-		project := SDProject name: 'unknown' ].
-	(version isNil or: [ version string isEmpty ]) ifTrue: [ 
-		version := (SDVersion string: 'unknown') project: project ]
 ]
 
 { #category : #'as yet unclassified' }

--- a/source/SnapDump-Core/SDFilesystemStore.class.st
+++ b/source/SnapDump-Core/SDFilesystemStore.class.st
@@ -5,7 +5,8 @@ Class {
 		'path',
 		'snapshots',
 		'projects',
-		'versions'
+		'versions',
+		'snapshotOccurrencesLimit'
 	],
 	#category : #'SnapDump-Core'
 }
@@ -15,38 +16,24 @@ SDFilesystemStore class >> storeName [
 	^ #file
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : #private }
 SDFilesystemStore >> buildSnapshotFrom: stream [
-	| projectName project versionString version snapshot dict |
 	
-	dict := SDFileSnapshot readMetaFrom: stream.
-	snapshot := SDFileSnapshot new initializeMeta: dict.
-	projectName := dict at: #projectName.
-	project := self projects 
-		at: projectName
-		ifAbsentPut: [ (SDProject name: projectName) store: self ].
-	versionString := dict at: #versionString.
-	version := (SDVersion string: versionString) project: project.
-	(versions
-		at: project
-		ifAbsentPut: [ Set new ]) add: version.
-		
-	^ snapshot
-		project: project;
-		version: version;
-		yourself
+		^ self buildSnapshotFrom: stream project: nil version: nil
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : #services }
 SDFilesystemStore >> buildSnapshotFrom: stream project: projectName version: versionName [
 	| project version snapshot dict |
 	
 	dict := SDFileSnapshot readMetaFrom: stream.
 	snapshot := SDFileSnapshot new initializeMeta: dict.
+	self ensureProjectTo: snapshot with: projectName.
+	self ensureVersionTo: snapshot with: versionName.
 	project := self projects 
-		at: projectName
-		ifAbsentPut: [ (SDProject name: projectName) store: self ].
-	version := (SDVersion string: versionName) project: project.
+		at: snapshot projectName
+		ifAbsentPut: [ (SDProject name: snapshot projectName) store: self ].
+	version := (SDVersion string: snapshot versionString) project: project; yourself.
 	(versions
 		at: project
 		ifAbsentPut: [ Set new ]) add: version.
@@ -57,7 +44,7 @@ SDFilesystemStore >> buildSnapshotFrom: stream project: projectName version: ver
 		yourself
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : #private }
 SDFilesystemStore >> buildSnapshots [
 	projects := Dictionary new.
 	versions := Dictionary new.
@@ -67,23 +54,54 @@ SDFilesystemStore >> buildSnapshots [
 			yourself ] 
 ]
 
-{ #category : #testing }
-SDFilesystemStore >> hasSnapshot: snapshot [
-	^ ( self snapshotPathFor: snapshot ) exists
+{ #category : #accessing }
+SDFilesystemStore >> defaultSnapshotOccurrencesLimit [
+
+	^ 10
+	
+	
+]
+
+{ #category : #private }
+SDFilesystemStore >> ensureProjectTo: snapshot with: projectName [
+	snapshot projectName isEmptyOrNil
+		ifTrue: [ projectName isEmptyOrNil
+				ifTrue: [ snapshot projectName: SDProject defaultProjectName]
+				ifFalse: [ snapshot projectName: projectName ] ].
+	^ snapshot projectName
+]
+
+{ #category : #private }
+SDFilesystemStore >> ensureVersionTo: snapshot with: versionName [
+	snapshot versionString isEmptyOrNil
+		ifTrue: [ versionName isEmptyOrNil
+				ifTrue: [ snapshot versionString: SDVersion defaultVersionString ]
+				ifFalse: [ snapshot versionString: versionName ] ].
+	^ snapshot versionString
 ]
 
 { #category : #testing }
-SDFilesystemStore >> hasSnapshot: snapshotId project: projectName version: versionName exception: exceptionId [
-	^ (self
-		snapshotPathForId: snapshotId
-		project: projectName
-		version: versionName
-		exceptionId: exceptionId) exists
+SDFilesystemStore >> hasSnapshot: snapshot [
+	^ self hasSnapshotId: snapshot snapshotId exceptionId:  snapshot exceptionId
+]
+
+{ #category : #testing }
+SDFilesystemStore >> hasSnapshotId: snapshotId exceptionId: exceptionId [
+	^ (self snapshots anySatisfy: [:eachSnapshot | eachSnapshot snapshotId = snapshotId])
+	 or: [ 
+				(self numberOfSnapshotsForException: exceptionId) >= self snapshotOccurrencesLimit 
+			 ]
 ]
 
 { #category : #testing }
 SDFilesystemStore >> isSetUp [
 	^ path notNil
+]
+
+{ #category : #accessing }
+SDFilesystemStore >> numberOfSnapshotsForException: anExceptionId [
+
+	^ (self snapshotsForException: anExceptionId) size
 ]
 
 { #category : #accessing }
@@ -93,50 +111,50 @@ SDFilesystemStore >> path: anObject [
 	self reset
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : #accessing }
 SDFilesystemStore >> projectNamed: aString [ 
 	^ self projects at: aString 
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : #accessing }
 SDFilesystemStore >> projectNamed: aString ifAbsent: aBlock [
 	^ self projects 
 		at: aString
 		ifAbsent: aBlock
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : #accessing }
 SDFilesystemStore >> projectNamed: aString ifAbsentPut: aBlock [
 	^ self projects 
 		at: aString 
 		ifAbsentPut: aBlock
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : #accessing }
 SDFilesystemStore >> projects [
 	^ projects 
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : #services }
 SDFilesystemStore >> removeProject: aProject [ 
 	"projects are derived from snapshots. Nothing to do"
 	^ aProject 
 ]
 
-{ #category : #'as yet unclassified' }
-SDFilesystemStore >> removeSnapshotWithId: aSnapshotId project: projectName version: versionName exception: exceptionId [ 
+{ #category : #services }
+SDFilesystemStore >> removeSnapshot: snapshot [
 	
-	(self snapshotPathForId: aSnapshotId project: projectName version: versionName exceptionId: exceptionId) delete.
+	(self snapshotPathFor: snapshot ) delete.
 	self reset
 	
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : #services }
 SDFilesystemStore >> removeVersion: aVersion [ 
 	"version are created from snapshots. So nothing to do"
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : #services }
 SDFilesystemStore >> reset [
 	super reset.
 	snapshots := nil.
@@ -145,36 +163,49 @@ SDFilesystemStore >> reset [
 	self buildSnapshots 
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : #accessing }
 SDFilesystemStore >> snapshotFiles [
 	^ path allChildrenMatching: '*.snap'
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : #accessing }
+SDFilesystemStore >> snapshotOccurrencesLimit [
+	"answers the maximum number of snapshots that should be stored for a same exception id"
+	
+		^ snapshotOccurrencesLimit ifNil: [ snapshotOccurrencesLimit := self defaultSnapshotOccurrencesLimit  ]
+	
+	
+]
+
+{ #category : #accessing }
+SDFilesystemStore >> snapshotOccurrencesLimit: aNumber [
+	
+		snapshotOccurrencesLimit := aNumber
+	
+	
+]
+
+{ #category : #services }
 SDFilesystemStore >> snapshotPathFor: aSnaphot [
 	^ self
 		snapshotPathForId: aSnaphot snapshotId
 		project: aSnaphot projectName
 		version: aSnaphot versionString
-		exceptionId: aSnaphot exceptionId
 ]
 
-{ #category : #'as yet unclassified' }
-SDFilesystemStore >> snapshotPathForId: snapshotId project: aProjectName version: aVersionName exceptionId: exceptionId [
+{ #category : #services }
+SDFilesystemStore >> snapshotPathForId: snapshotId project: aProjectName version: aVersionName [
 	^ (((path / aProjectName)
 		ensureCreateDirectory;
 		/ aVersionName)
-		ensureCreateDirectory;
-		/ exceptionId) ensureCreateDirectory / snapshotId , #snap
+		ensureCreateDirectory)/ snapshotId , #snap
 ]
 
-{ #category : #'as yet unclassified' }
-SDFilesystemStore >> snapshotWithId: aString project: aProjectName version: aVersionName exceptionId: anExceptionId [
+{ #category : #services }
+SDFilesystemStore >> snapshotWithId: aString [ 
 	^ self snapshots
 		detect: [ :each | 
-			((each snapshotId = aString and: [ each projectName = aProjectName ])
-				and: [ each versionString = aVersionName ])
-				and: [ each exceptionId = anExceptionId ] ]
+			each snapshotId = aString ]
 		ifNone: [ NotFound signal ]
 ]
 
@@ -184,25 +215,39 @@ SDFilesystemStore >> snapshots [
 		
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : #accessing }
+SDFilesystemStore >> snapshotsForException: anExceptionId [
+
+	^ self snapshots select: [ :eachSnapshot |
+			eachSnapshot exceptionId = anExceptionId
+		 ]
+]
+
+{ #category : #services }
+SDFilesystemStore >> snapshotsWithProject: projectName version: versionString [
+	^ self snapshots
+		select: [ :each | (each project name = projectName) and: [ each version string = versionString] ]
+]
+
+{ #category : #services }
 SDFilesystemStore >> snapshotsWithVersion: aVersion [ 
 	^ self snapshots
 		select: [ :each | (each project name = aVersion project name) and: [ each version string = aVersion string ] ]
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : #services }
 SDFilesystemStore >> storeRaw: snapshot contents: aByteArray [
 	snapshot file: (self snapshotPathFor: snapshot).
 	snapshot storeRaw: aByteArray.
 	self reset
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : #accessing }
 SDFilesystemStore >> versionsOfProject: aProject [ 
 	^ versions at: aProject ifAbsent: [ #() ]
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : #services }
 SDFilesystemStore >> writeSnapshot: snapshot [
 	| stream file |
 	file := self snapshotPathFor: snapshot.

--- a/source/SnapDump-Core/SDFilesystemStore.class.st
+++ b/source/SnapDump-Core/SDFilesystemStore.class.st
@@ -38,6 +38,26 @@ SDFilesystemStore >> buildSnapshotFrom: stream [
 ]
 
 { #category : #'as yet unclassified' }
+SDFilesystemStore >> buildSnapshotFrom: stream project: projectName version: versionName [
+	| project version snapshot dict |
+	
+	dict := SDFileSnapshot readMetaFrom: stream.
+	snapshot := SDFileSnapshot new initializeMeta: dict.
+	project := self projects 
+		at: projectName
+		ifAbsentPut: [ (SDProject name: projectName) store: self ].
+	version := (SDVersion string: versionName) project: project.
+	(versions
+		at: project
+		ifAbsentPut: [ Set new ]) add: version.
+		
+	^ snapshot
+		project: project;
+		version: version;
+		yourself
+]
+
+{ #category : #'as yet unclassified' }
 SDFilesystemStore >> buildSnapshots [
 	projects := Dictionary new.
 	versions := Dictionary new.
@@ -48,8 +68,17 @@ SDFilesystemStore >> buildSnapshots [
 ]
 
 { #category : #testing }
-SDFilesystemStore >> hasSnapshotNamed: snapshotId [
-	^ ( self snapshotPathFor: snapshotId ) exists
+SDFilesystemStore >> hasSnapshot: snapshot [
+	^ ( self snapshotPathFor: snapshot ) exists
+]
+
+{ #category : #testing }
+SDFilesystemStore >> hasSnapshot: snapshotId project: projectName version: versionName exception: exceptionId [
+	^ (self
+		snapshotPathForId: snapshotId
+		project: projectName
+		version: versionName
+		exceptionId: exceptionId) exists
 ]
 
 { #category : #testing }
@@ -95,9 +124,9 @@ SDFilesystemStore >> removeProject: aProject [
 ]
 
 { #category : #'as yet unclassified' }
-SDFilesystemStore >> removeSnapshotWithId: aString [ 
+SDFilesystemStore >> removeSnapshotWithId: aSnapshotId project: projectName version: versionName exception: exceptionId [ 
 	
-	(self snapshotPathFor: aString) delete.
+	(self snapshotPathForId: aSnapshotId project: projectName version: versionName exceptionId: exceptionId) delete.
 	self reset
 	
 ]
@@ -118,18 +147,30 @@ SDFilesystemStore >> reset [
 
 { #category : #'as yet unclassified' }
 SDFilesystemStore >> snapshotFiles [
-	^ path childrenMatching: '*.snap'
+	^ path allChildrenMatching: '*.snap'
 ]
 
 { #category : #'as yet unclassified' }
-SDFilesystemStore >> snapshotPathFor: aString [ 
-	^ (path / aString) , #snap
+SDFilesystemStore >> snapshotPathFor: aSnaphot [
+	^ self
+		snapshotPathForId: aSnaphot snapshotId
+		project: aSnaphot projectName
+		version: aSnaphot versionString
+		exceptionId: aSnaphot exceptionId
 ]
 
 { #category : #'as yet unclassified' }
-SDFilesystemStore >> snapshotWithId: aString [ 
-	^ self snapshots 
-		detect: [ :each | each id = aString ]
+SDFilesystemStore >> snapshotPathForId: snapshotId project: aProjectName version: aVersionName exceptionId: exceptionId [
+	^ (path / aProjectName / aVersionName / exceptionId / snapshotId) , #snap
+]
+
+{ #category : #'as yet unclassified' }
+SDFilesystemStore >> snapshotWithId: aString project: aProjectName version: aVersionName exceptionId: anExceptionId [
+	^ self snapshots
+		detect: [ :each | 
+			((each snapshotId = aString and: [ each projectName = aProjectName ])
+				and: [ each versionString = aVersionName ])
+				and: [ each exceptionId = anExceptionId ] ]
 		ifNone: [ NotFound signal ]
 ]
 
@@ -147,7 +188,7 @@ SDFilesystemStore >> snapshotsWithVersion: aVersion [
 
 { #category : #'as yet unclassified' }
 SDFilesystemStore >> storeRaw: snapshot contents: aByteArray [
-	snapshot file: (self snapshotPathFor: snapshot id).
+	snapshot file: (self snapshotPathFor: snapshot).
 	snapshot storeRaw: aByteArray.
 	self reset
 ]
@@ -160,7 +201,7 @@ SDFilesystemStore >> versionsOfProject: aProject [
 { #category : #'as yet unclassified' }
 SDFilesystemStore >> writeSnapshot: snapshot [
 	| stream file |
-	file := (path / snapshot id) , #snap.
+	file := self snapshotPathFor: snapshot.
 	stream := file fileSystem  binaryWriteStreamOn: file path.
 	[ snapshot writeTo: stream ]
 		ensure: [ stream close ]

--- a/source/SnapDump-Core/SDFilesystemStore.class.st
+++ b/source/SnapDump-Core/SDFilesystemStore.class.st
@@ -161,7 +161,11 @@ SDFilesystemStore >> snapshotPathFor: aSnaphot [
 
 { #category : #'as yet unclassified' }
 SDFilesystemStore >> snapshotPathForId: snapshotId project: aProjectName version: aVersionName exceptionId: exceptionId [
-	^ (path / aProjectName / aVersionName / exceptionId / snapshotId) , #snap
+	^ (((path / aProjectName)
+		ensureCreateDirectory;
+		/ aVersionName)
+		ensureCreateDirectory;
+		/ exceptionId) ensureCreateDirectory / snapshotId , #snap
 ]
 
 { #category : #'as yet unclassified' }

--- a/source/SnapDump-Core/SDFilesystemStore.class.st
+++ b/source/SnapDump-Core/SDFilesystemStore.class.st
@@ -3,10 +3,9 @@ Class {
 	#superclass : #SDStore,
 	#instVars : [
 		'path',
-		'snapshots',
+		'snapshotOccurrencesLimit',
 		'projects',
-		'versions',
-		'snapshotOccurrencesLimit'
+		'versions'
 	],
 	#category : #'SnapDump-Core'
 }
@@ -16,81 +15,48 @@ SDFilesystemStore class >> storeName [
 	^ #file
 ]
 
-{ #category : #private }
-SDFilesystemStore >> buildSnapshotFrom: stream [
-	
-		^ self buildSnapshotFrom: stream project: nil version: nil
+{ #category : #services }
+SDFilesystemStore >> buildSnapshot: snapshotId exception: exceptionId project: projectName version: versionName [
+	.
+	^ (self buildSnapshot: snapshotId project: projectName version: versionName) exceptionId: exceptionId; yourself
 ]
 
 { #category : #services }
-SDFilesystemStore >> buildSnapshotFrom: stream project: projectName version: versionName [
-	| project version snapshot dict |
-	
-	dict := SDFileSnapshot readMetaFrom: stream.
-	snapshot := SDFileSnapshot new initializeMeta: dict.
-	self ensureProjectTo: snapshot with: projectName.
-	self ensureVersionTo: snapshot with: versionName.
-	project := self projects 
-		at: snapshot projectName
-		ifAbsentPut: [ (SDProject name: snapshot projectName) store: self ].
-	version := (SDVersion string: snapshot versionString) project: project; yourself.
-	(versions
-		at: project
-		ifAbsentPut: [ Set new ]) add: version.
-		
-	^ snapshot
-		project: project;
-		version: version;
+SDFilesystemStore >> buildSnapshot: snapshotId project: projectName version: versionName [
+	.
+	^ SDFileSnapshot new
+		snapshotId: snapshotId;
+		projectName: projectName;
+		versionString: versionName;
 		yourself
 ]
 
-{ #category : #private }
-SDFilesystemStore >> buildSnapshots [
-	projects := Dictionary new.
-	versions := Dictionary new.
-	snapshots := self snapshotFiles collect: [ :file |
-		(self buildSnapshotFrom: file binaryReadStream)
-			file: file;
-			yourself ] 
-]
-
-{ #category : #accessing }
-SDFilesystemStore >> defaultSnapshotOccurrencesLimit [
-
-	^ 10
+{ #category : #'services - removing' }
+SDFilesystemStore >> cleanSnapshotRemoval: file [
 	
+	| versionDirectory projectDirectory exceptionDirectory |
+	exceptionDirectory := file parent.
+	versionDirectory := exceptionDirectory parent.
+	projectDirectory := versionDirectory parent.
+	exceptionDirectory hasChildren ifFalse: [ exceptionDirectory delete ].
+	versionDirectory hasChildren ifFalse: [ versionDirectory delete ].
+	projectDirectory hasChildren ifFalse: [ projectDirectory delete  ].
 	
 ]
 
-{ #category : #private }
-SDFilesystemStore >> ensureProjectTo: snapshot with: projectName [
-	snapshot projectName isEmptyOrNil
-		ifTrue: [ projectName isEmptyOrNil
-				ifTrue: [ snapshot projectName: SDProject defaultProjectName]
-				ifFalse: [ snapshot projectName: projectName ] ].
-	^ snapshot projectName
-]
+{ #category : #testing }
+SDFilesystemStore >> hasSnapshot: aSnapshot [
 
-{ #category : #private }
-SDFilesystemStore >> ensureVersionTo: snapshot with: versionName [
-	snapshot versionString isEmptyOrNil
-		ifTrue: [ versionName isEmptyOrNil
-				ifTrue: [ snapshot versionString: SDVersion defaultVersionString ]
-				ifFalse: [ snapshot versionString: versionName ] ].
-	^ snapshot versionString
+
+	^ self hasSnapshot: aSnapshot snapshotId project: aSnapshot projectName version: aSnapshot versionString
+
 ]
 
 { #category : #testing }
-SDFilesystemStore >> hasSnapshot: snapshot [
-	^ self hasSnapshotId: snapshot snapshotId exceptionId:  snapshot exceptionId
-]
-
-{ #category : #testing }
-SDFilesystemStore >> hasSnapshotId: snapshotId exceptionId: exceptionId [
-	^ (self snapshots anySatisfy: [:eachSnapshot | eachSnapshot snapshotId = snapshotId])
-	 or: [ 
-				(self numberOfSnapshotsForException: exceptionId) >= self snapshotOccurrencesLimit 
-			 ]
+SDFilesystemStore >> hasSnapshot: snapshotId project: aProjectName version: aVersionName [
+	^ (self snapshotFilesForProject: aProjectName version: aVersionName)
+		anySatisfy:
+			[ :eachFile | eachFile basename = self snapshotFileNameFor: snapshotId ]
 ]
 
 { #category : #testing }
@@ -99,73 +65,97 @@ SDFilesystemStore >> isSetUp [
 ]
 
 { #category : #accessing }
-SDFilesystemStore >> numberOfSnapshotsForException: anExceptionId [
-
-	^ (self snapshotsForException: anExceptionId) size
-]
-
-{ #category : #accessing }
 SDFilesystemStore >> path: anObject [
 	path := anObject asFileReference.
 	path ensureCreateDirectory.
-	self reset
 ]
 
 { #category : #accessing }
 SDFilesystemStore >> projectNamed: aString [ 
-	^ self projects at: aString 
+
+	| file project |
+	file := self snapshotPathForProject: aString.
+	file exists ifFalse: [NotFound signal].
+	project := (SDProject name: aString) store: self.
+	^ project
 ]
 
 { #category : #accessing }
 SDFilesystemStore >> projectNamed: aString ifAbsent: aBlock [
-	^ self projects 
-		at: aString
-		ifAbsent: aBlock
-]
-
-{ #category : #accessing }
-SDFilesystemStore >> projectNamed: aString ifAbsentPut: aBlock [
-	^ self projects 
-		at: aString 
-		ifAbsentPut: aBlock
+	^ [self projectNamed: aString] on: NotFound do: [ :ex | aBlock value ]
 ]
 
 { #category : #accessing }
 SDFilesystemStore >> projects [
-	^ projects 
+	^ path children collect: [ :directory |
+		 (SDProject name: directory basename) store: self.
+		 ]
 ]
 
-{ #category : #services }
+{ #category : #'services - removing' }
 SDFilesystemStore >> removeProject: aProject [ 
 	"projects are derived from snapshots. Nothing to do"
 	^ aProject 
 ]
 
-{ #category : #services }
+{ #category : #'services - removing' }
 SDFilesystemStore >> removeSnapshot: snapshot [
 	
-	(self snapshotPathFor: snapshot ) delete.
-	self reset
+	| file |
+	file := (self snapshotPathFor: snapshot ).
+	file delete.
+	self cleanSnapshotRemoval: file.
 	
 ]
 
-{ #category : #services }
+{ #category : #'services - removing' }
 SDFilesystemStore >> removeVersion: aVersion [ 
 	"version are created from snapshots. So nothing to do"
 ]
 
-{ #category : #services }
-SDFilesystemStore >> reset [
-	super reset.
-	snapshots := nil.
-	projects := nil.
-	versions := nil.
-	self buildSnapshots 
+{ #category : #testing }
+SDFilesystemStore >> shouldReportProject: projectName version: versionName exception: exceptionId [
+
+	| directory |
+	directory := (self snapshotPathForException: exceptionId project: projectName version: versionName).
+	directory exists ifFalse: [ ^ true ]. 
+	^ directory children size < self snapshotOccurrencesLimit
+]
+
+{ #category : #testing }
+SDFilesystemStore >> shouldReportSnapshot: snapshot [
+	^ (self
+		hasSnapshot: snapshot) not
+		and: [ self
+				shouldReportProject: snapshot projectName
+				version: snapshot versionString
+				exception: snapshot exceptionId ]
+]
+
+{ #category : #'services - files' }
+SDFilesystemStore >> snapshotFileNameFor: snapshotId [
+
+	^ snapshotId , '.snap'
 ]
 
 { #category : #accessing }
 SDFilesystemStore >> snapshotFiles [
 	^ path allChildrenMatching: '*.snap'
+]
+
+{ #category : #'services - files' }
+SDFilesystemStore >> snapshotFilesForProject: aProjectName version: aVersionName [
+
+	| directory |
+	directory := self snapshotPathForProject: aProjectName version: aVersionName.
+	directory exists ifFalse: [ ^ #() ].
+	^ directory allFiles
+]
+
+{ #category : #'services - files' }
+SDFilesystemStore >> snapshotIdFrom: aFileBasename [
+
+	^ aFileBasename asFileReference basenameWithoutExtension
 ]
 
 { #category : #accessing }
@@ -185,72 +175,108 @@ SDFilesystemStore >> snapshotOccurrencesLimit: aNumber [
 	
 ]
 
-{ #category : #services }
+{ #category : #'services - files' }
 SDFilesystemStore >> snapshotPathFor: aSnaphot [
+
+
 	^ self
 		snapshotPathForId: aSnaphot snapshotId
+		exception: aSnaphot exceptionId
 		project: aSnaphot projectName
 		version: aSnaphot versionString
 ]
 
-{ #category : #services }
-SDFilesystemStore >> snapshotPathForId: snapshotId project: aProjectName version: aVersionName [
-	^ (((path / aProjectName)
-		ensureCreateDirectory;
-		/ aVersionName)
-		ensureCreateDirectory)/ snapshotId , #snap
+{ #category : #'services - files' }
+SDFilesystemStore >> snapshotPathForException: exceptionId project: projectName version: versionName [
+	^ (self snapshotPathForProject: projectName version: versionName)/ exceptionId
+]
+
+{ #category : #'services - files' }
+SDFilesystemStore >> snapshotPathForId: snapshotId exception: exceptionId project: aProjectName version: aVersionName [
+	^ (self snapshotPathForException: exceptionId project: aProjectName version: aVersionName) / (self snapshotFileNameFor: snapshotId)
+]
+
+{ #category : #'services - files' }
+SDFilesystemStore >> snapshotPathForProject: projectName [ 
+	^ path / projectName 
+]
+
+{ #category : #'services - files' }
+SDFilesystemStore >> snapshotPathForProject: projectName version: versionName [
+	^ (self snapshotPathForProject: projectName) / versionName 
 ]
 
 { #category : #services }
-SDFilesystemStore >> snapshotWithId: aString [ 
-	^ self snapshots
-		detect: [ :each | 
-			each snapshotId = aString ]
-		ifNone: [ NotFound signal ]
-]
-
-{ #category : #accessing }
-SDFilesystemStore >> snapshots [
-	^ snapshots 
-		
-]
-
-{ #category : #accessing }
-SDFilesystemStore >> snapshotsForException: anExceptionId [
-
-	^ self snapshots select: [ :eachSnapshot |
-			eachSnapshot exceptionId = anExceptionId
-		 ]
+SDFilesystemStore >> snapshotWithId: anIdString [
+	| file |
+	file := self snapshotFiles
+		detect:
+			[ :eachFile | eachFile basename = (self snapshotFileNameFor: anIdString) ]
+		ifNone: [ NotFound signal ].
+	
+	^ (self
+		buildSnapshot: anIdString
+		exception: file parent basename
+		project: file parent parent parent basename
+		version: file parent parent basename)
+		file: file;
+		yourself
 ]
 
 { #category : #services }
-SDFilesystemStore >> snapshotsWithProject: projectName version: versionString [
-	^ self snapshots
-		select: [ :each | (each project name = projectName) and: [ each version string = versionString] ]
+SDFilesystemStore >> snapshotWithId: anIdString project: aProjectName version: aVersionString [
+	| file |
+	file := (self
+		snapshotFilesForProject: aProjectName
+		version: aVersionString)
+		detect:
+			[ :eachFile | eachFile basename = (self snapshotFileNameFor: anIdString) ]
+		ifNone: [ NotFound signal ].
+	^ (self
+		buildSnapshot: anIdString
+		exception: file parent basename
+		project: aProjectName
+		version: aVersionString)
+		file: file;
+		yourself
 ]
 
 { #category : #services }
-SDFilesystemStore >> snapshotsWithVersion: aVersion [ 
-	^ self snapshots
-		select: [ :each | (each project name = aVersion project name) and: [ each version string = aVersion string ] ]
+SDFilesystemStore >> snapshotsWithVersion: aVersion [
+
+	^ (self
+		snapshotFilesForProject: aVersion project name
+		version: aVersion string)
+		collect: [ :eachFile | 
+			(SDFileSnapshot fromFile: eachFile)  ]
 ]
 
-{ #category : #services }
+{ #category : #'services - adding' }
 SDFilesystemStore >> storeRaw: snapshot contents: aByteArray [
-	snapshot file: (self snapshotPathFor: snapshot).
+
+	| file |
+	file := (self snapshotPathFor: snapshot).
+	file parent  ensureCreateDirectory. 
+	snapshot file: file.
 	snapshot storeRaw: aByteArray.
-	self reset
+
 ]
 
 { #category : #accessing }
 SDFilesystemStore >> versionsOfProject: aProject [ 
-	^ versions at: aProject ifAbsent: [ #() ]
+	| file |
+	file := (self snapshotPathForProject:  aProject name). 
+	file exists ifFalse: [ ^ #() ].
+	^ file children collect: [ :eachDirectory |
+		(SDVersion string: eachDirectory basename) project: aProject
+		 ].
 ]
 
-{ #category : #services }
+{ #category : #'services - adding' }
 SDFilesystemStore >> writeSnapshot: snapshot [
 	| stream file |
 	file := self snapshotPathFor: snapshot.
+	file parent ensureCreateDirectory.
 	stream := file fileSystem  binaryWriteStreamOn: file path.
 	[ snapshot writeTo: stream ]
 		ensure: [ stream close ]

--- a/source/SnapDump-Core/SDProject.class.st
+++ b/source/SnapDump-Core/SDProject.class.st
@@ -8,6 +8,12 @@ Class {
 	#category : #'SnapDump-Core'
 }
 
+{ #category : #accessing }
+SDProject class >> defaultProjectName [
+
+	^ 'unknown'
+]
+
 { #category : #'instance creation' }
 SDProject class >> name: aString [ 
 	^ self new name: aString 

--- a/source/SnapDump-Core/SDSnapshot.class.st
+++ b/source/SnapDump-Core/SDSnapshot.class.st
@@ -14,7 +14,9 @@ Class {
 		'operatingSystemVersion',
 		'vmVersion',
 		'imageVersion',
-		'imageBuild'
+		'imageBuild',
+		'snapshotId',
+		'exceptionId'
 	],
 	#category : #'SnapDump-Core'
 }
@@ -34,7 +36,7 @@ SDSnapshot class >> neoJsonMapping: mapper [
 	mapper for: self do: [ :mapping |
 		mapping mapAccessors: #( projectName versionString ).
 		(mapping mapInstVar: #timestamp) valueSchema: DateAndTime.
-		mapping mapInstVars: #(id className selector exceptionClass operatingSystem systemArchitecture operatingSystemVersion vmVersion imageVersion imageBuild) ].
+		mapping mapInstVars: #(id exceptionId snapshotId className selector exceptionClass operatingSystem systemArchitecture operatingSystemVersion vmVersion imageVersion imageBuild) ].
 	mapper for: DateAndTime customDo: [ :mapping |
 		mapping decoder: [ :string | DateAndTime fromString: string ].
 		mapping encoder: [ :dateAndTime | dateAndTime printString ] ].
@@ -51,9 +53,21 @@ SDSnapshot >> basicMetaFields [
 	^ #(id timestamp className selector exceptionClass operatingSystem systemArchitecture operatingSystemVersion vmVersion imageVersion imageBuild)
 ]
 
-{ #category : #accessing }
+{ #category : #private }
+SDSnapshot >> buildExceptionId [
+	^ (SHA256 hashMessage: self errorSignature) hex
+
+]
+
+{ #category : #private }
 SDSnapshot >> buildId [
 	^ (SHA256 hashMessage: self fullSignature) hex
+
+]
+
+{ #category : #private }
+SDSnapshot >> buildSnapshotId [
+	^ (SHA256 hashMessage: self snapshotSignature) hex
 
 ]
 
@@ -103,6 +117,12 @@ SDSnapshot >> exceptionClass [
 { #category : #accessing }
 SDSnapshot >> exceptionClass: aString [ 
 	exceptionClass := aString
+]
+
+{ #category : #accessing }
+SDSnapshot >> exceptionId [ 
+	^ exceptionId ifNil: [ 
+		exceptionId := self buildSnapshotId ]
 ]
 
 { #category : #signatures }
@@ -233,6 +253,25 @@ SDSnapshot >> selector [
 { #category : #accessing }
 SDSnapshot >> selector: aString [ 
 	selector := aString
+]
+
+{ #category : #accessing }
+SDSnapshot >> snapshotId [ 
+	^ snapshotId ifNil: [ 
+		snapshotId := self buildSnapshotId ]
+]
+
+{ #category : #signatures }
+SDSnapshot >> snapshotSignature [
+	^ String streamContents: [ :stream |
+		stream 
+			<< className 
+			<< '_'
+			<< selector 
+			<< '_'
+			<< exceptionClass 
+			<< '_'
+			<< timestamp printString ]
 ]
 
 { #category : #accessing }

--- a/source/SnapDump-Core/SDSnapshot.class.st
+++ b/source/SnapDump-Core/SDSnapshot.class.st
@@ -131,6 +131,11 @@ SDSnapshot >> exceptionId [
 ]
 
 { #category : #accessing }
+SDSnapshot >> exceptionId: aString [
+	exceptionId := aString
+]
+
+{ #category : #accessing }
 SDSnapshot >> imageBuild [
 	^ imageBuild
 ]
@@ -237,6 +242,11 @@ SDSnapshot >> selector: aString [
 SDSnapshot >> snapshotId [ 
 	^ snapshotId ifNil: [ 
 		snapshotId := self buildSnapshotId ]
+]
+
+{ #category : #accessing }
+SDSnapshot >> snapshotId: aString [
+	snapshotId := aString
 ]
 
 { #category : #signatures }

--- a/source/SnapDump-Core/SDSnapshot.class.st
+++ b/source/SnapDump-Core/SDSnapshot.class.st
@@ -50,7 +50,7 @@ SDSnapshot >> asSnapshot [
 
 { #category : #private }
 SDSnapshot >> basicMetaFields [
-	^ #(id timestamp className selector exceptionClass operatingSystem systemArchitecture operatingSystemVersion vmVersion imageVersion imageBuild)
+	^ #(snapshotId exceptionId timestamp className selector exceptionClass operatingSystem systemArchitecture operatingSystemVersion vmVersion imageVersion imageBuild)
 ]
 
 { #category : #private }

--- a/source/SnapDump-Core/SDSnapshot.class.st
+++ b/source/SnapDump-Core/SDSnapshot.class.st
@@ -2,7 +2,6 @@ Class {
 	#name : #SDSnapshot,
 	#superclass : #Object,
 	#instVars : [
-		'id',
 		'timestamp',
 		'project',
 		'version',
@@ -16,7 +15,9 @@ Class {
 		'imageVersion',
 		'imageBuild',
 		'snapshotId',
-		'exceptionId'
+		'exceptionId',
+		'versionString',
+		'projectName'
 	],
 	#category : #'SnapDump-Core'
 }
@@ -36,7 +37,7 @@ SDSnapshot class >> neoJsonMapping: mapper [
 	mapper for: self do: [ :mapping |
 		mapping mapAccessors: #( projectName versionString ).
 		(mapping mapInstVar: #timestamp) valueSchema: DateAndTime.
-		mapping mapInstVars: #(id exceptionId snapshotId className selector exceptionClass operatingSystem systemArchitecture operatingSystemVersion vmVersion imageVersion imageBuild) ].
+		mapping mapInstVars: #(exceptionId snapshotId className selector exceptionClass operatingSystem systemArchitecture operatingSystemVersion vmVersion imageVersion imageBuild) ].
 	mapper for: DateAndTime customDo: [ :mapping |
 		mapping decoder: [ :string | DateAndTime fromString: string ].
 		mapping encoder: [ :dateAndTime | dateAndTime printString ] ].
@@ -50,18 +51,12 @@ SDSnapshot >> asSnapshot [
 
 { #category : #private }
 SDSnapshot >> basicMetaFields [
-	^ #(snapshotId exceptionId timestamp className selector exceptionClass operatingSystem systemArchitecture operatingSystemVersion vmVersion imageVersion imageBuild)
+	^ #(projectName versionString snapshotId exceptionId timestamp className selector exceptionClass operatingSystem systemArchitecture operatingSystemVersion vmVersion imageVersion imageBuild)
 ]
 
 { #category : #private }
 SDSnapshot >> buildExceptionId [
 	^ (SHA256 hashMessage: self errorSignature) hex
-
-]
-
-{ #category : #private }
-SDSnapshot >> buildId [
-	^ (SHA256 hashMessage: self fullSignature) hex
 
 ]
 
@@ -81,13 +76,13 @@ SDSnapshot >> className: aString [
 	className := aString
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : #accessing }
 SDSnapshot >> dateAndTimeString [ 
 	^ String streamContents: [ :stream |
 		stream << self dateString << ' ' << self timeString  ]
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : #accessing }
 SDSnapshot >> dateString [ 
 	^ timestamp asDate printFormat: #(1 2 3 $. 1 1)
 ]
@@ -101,12 +96,22 @@ SDSnapshot >> encodeMetaOn: aSerializer [
 { #category : #signatures }
 SDSnapshot >> errorSignature [
 	^ String streamContents: [ :stream |
-		stream 
+		self errorSignatureOn: stream  ]
+]
+
+{ #category : #signatures }
+SDSnapshot >> errorSignatureOn: stream [
+
+	^  stream 
+			<< self projectName asString 
+			<< '_'
+			<< self versionString asString 
+			<< '_'
 			<< className 
 			<< '_'
 			<< selector 
 			<< '_'
-			<< exceptionClass  ]
+			<< exceptionClass 
 ]
 
 { #category : #accessing }
@@ -122,33 +127,7 @@ SDSnapshot >> exceptionClass: aString [
 { #category : #accessing }
 SDSnapshot >> exceptionId [ 
 	^ exceptionId ifNil: [ 
-		exceptionId := self buildSnapshotId ]
-]
-
-{ #category : #signatures }
-SDSnapshot >> fullSignature [
-	^ String streamContents: [ :stream |
-		stream 
-			<< self projectName asString 
-			<< '_'
-			<< self versionString asString 
-			<< '_'
-			<< className 
-			<< '_'
-			<< selector 
-			<< '_'
-			<< exceptionClass  ]
-]
-
-{ #category : #accessing }
-SDSnapshot >> id [ 
-	^ id ifNil: [ 
-		id := self buildId ]
-]
-
-{ #category : #accessing }
-SDSnapshot >> id: anObject [
-	id := anObject
+		exceptionId := self buildExceptionId ]
 ]
 
 { #category : #accessing }
@@ -180,9 +159,6 @@ SDSnapshot >> initialize [
 { #category : #private }
 SDSnapshot >> metaFields [
 	^ self basicMetaFields asOrderedCollection
-		add: #projectName;
-		add: #versionString;
-		yourself
 ]
 
 { #category : #signatures }
@@ -197,7 +173,7 @@ SDSnapshot >> methodSignature [
 { #category : #actions }
 SDSnapshot >> openDebugger [
 	FLMaterializer materializeFromByteArray: (
-		self store snapshotDumpWithId: id )
+		self store snapshotDumpFor: self )
 ]
 
 { #category : #accessing }
@@ -227,17 +203,19 @@ SDSnapshot >> project [
 
 { #category : #accessing }
 SDSnapshot >> project: aProject [
-	project := aProject
+	project := aProject.
+	projectName :=  aProject name
 ]
 
 { #category : #accessing }
 SDSnapshot >> projectName [
-	^ project name
+	^ projectName
 ]
 
 { #category : #accessing }
-SDSnapshot >> projectName: aString [ 
-	"we only use project objects"
+SDSnapshot >> projectName: aString [
+	
+	projectName := aString
 ]
 
 { #category : #actions }
@@ -264,12 +242,8 @@ SDSnapshot >> snapshotId [
 { #category : #signatures }
 SDSnapshot >> snapshotSignature [
 	^ String streamContents: [ :stream |
+		self errorSignatureOn: stream.
 		stream 
-			<< className 
-			<< '_'
-			<< selector 
-			<< '_'
-			<< exceptionClass 
 			<< '_'
 			<< timestamp printString ]
 ]
@@ -289,7 +263,7 @@ SDSnapshot >> systemArchitecture: aString [
 	systemArchitecture := aString
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : #accessing }
 SDSnapshot >> timeString [ 
 	^ timestamp asTime print24
 ]
@@ -316,17 +290,19 @@ SDSnapshot >> version [
 { #category : #accessing }
 SDSnapshot >> version: aVersion [
 	version := aVersion.
+	versionString := aVersion string.
 	project := aVersion project
 ]
 
 { #category : #accessing }
 SDSnapshot >> versionString [
-	^ version string
+	^ versionString
 ]
 
 { #category : #accessing }
 SDSnapshot >> versionString: aString [ 
-	"we only use version object"
+	
+	versionString := aString
 ]
 
 { #category : #accessing }

--- a/source/SnapDump-Core/SDStore.class.st
+++ b/source/SnapDump-Core/SDStore.class.st
@@ -10,7 +10,7 @@ SDStore class >> withName: aString [
 ]
 
 { #category : #testing }
-SDStore >> hasSnapshot: aString [
+SDStore >> hasSnapshot: aSnapshot [
 	self subclassResponsibility 
 ]
 
@@ -19,11 +19,10 @@ SDStore >> isSetUp [
 	self subclassResponsibility 
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : #services }
 SDStore >> removeSnapshot: aSnapshot [ 
 	
-	(self snapshotPathFor: aSnapshot) delete.
-	self reset
+	^ self subclassResponsibility 
 
 ]
 
@@ -31,7 +30,7 @@ SDStore >> removeSnapshot: aSnapshot [
 SDStore >> reset [
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : #services }
 SDStore >> storeSnapshot: snapshot [
 	Transcript show: 'SnapDump: checking if error needs to be reported'.
 	(self hasSnapshot: snapshot)

--- a/source/SnapDump-Core/SDStore.class.st
+++ b/source/SnapDump-Core/SDStore.class.st
@@ -10,7 +10,7 @@ SDStore class >> withName: aString [
 ]
 
 { #category : #testing }
-SDStore >> hasSnapshotNamed: aString [
+SDStore >> hasSnapshot: aString [
 	self subclassResponsibility 
 ]
 
@@ -22,7 +22,8 @@ SDStore >> isSetUp [
 { #category : #'as yet unclassified' }
 SDStore >> removeSnapshot: aSnapshot [ 
 	
-	^ self removeSnapshotWithId: aSnapshot id.
+	(self snapshotPathFor: aSnapshot) delete.
+	self reset
 
 ]
 
@@ -33,7 +34,7 @@ SDStore >> reset [
 { #category : #'as yet unclassified' }
 SDStore >> storeSnapshot: snapshot [
 	Transcript show: 'SnapDump: checking if error needs to be reported'.
-	(self hasSnapshotNamed: snapshot id)
+	(self hasSnapshot: snapshot)
 		ifFalse: [ 
 			Transcript show: 'SnapDump: error is being uploaded'.
 			self writeSnapshot: snapshot.

--- a/source/SnapDump-Core/SDStore.class.st
+++ b/source/SnapDump-Core/SDStore.class.st
@@ -9,9 +9,12 @@ SDStore class >> withName: aString [
 	^ self subclasses detect: [ :each | each storeName = aString ]
 ]
 
-{ #category : #testing }
-SDStore >> hasSnapshot: aSnapshot [
-	self subclassResponsibility 
+{ #category : #accessing }
+SDStore >> defaultSnapshotOccurrencesLimit [
+
+	^ 10
+	
+	
 ]
 
 { #category : #testing }
@@ -30,14 +33,19 @@ SDStore >> removeSnapshot: aSnapshot [
 SDStore >> reset [
 ]
 
+{ #category : #testing }
+SDStore >> shouldReportSnapshot: aSnapshot [
+	self subclassResponsibility 
+]
+
 { #category : #services }
 SDStore >> storeSnapshot: snapshot [
 	Transcript show: 'SnapDump: checking if error needs to be reported'.
-	(self hasSnapshot: snapshot)
-		ifFalse: [ 
+	(self shouldReportSnapshot: snapshot)
+		ifTrue: [ 
 			Transcript show: 'SnapDump: error is being uploaded'.
 			self writeSnapshot: snapshot.
-			self reset ]
+	]
 ]
 
 { #category : #writing }

--- a/source/SnapDump-Core/SDVersion.class.st
+++ b/source/SnapDump-Core/SDVersion.class.st
@@ -9,6 +9,12 @@ Class {
 }
 
 { #category : #accessing }
+SDVersion class >> defaultVersionString [
+
+	^ 'unknown'
+]
+
+{ #category : #accessing }
 SDVersion class >> neoJsonMapping: mapper [
 	mapper for: self do: [ :mapping |
 		mapping mapInstVars: #(string) ]
@@ -77,7 +83,7 @@ SDVersion >> store [
 
 { #category : #accessing }
 SDVersion >> string [
-	^ string
+	^ string 
 ]
 
 { #category : #accessing }

--- a/source/SnapDump-Core/SnapDump.class.st
+++ b/source/SnapDump-Core/SnapDump.class.st
@@ -76,7 +76,7 @@ SnapDump class >> withType: aSymbol [
 	^ self allSubclasses detect: [ :each | each type = aSymbol ]
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : #initialization }
 SnapDump >> applyConfiguration: aConfig [
 	store := (SDStore withName: aConfig store) new.
 	store applyConfiguration: aConfig
@@ -98,7 +98,7 @@ SnapDump >> store: anObject [
 	store := anObject 
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : #initialization }
 SnapDump >> uri: aUri username: aUsername password: aPassword [
 	^ self store 
 			uri: aUri asZnUrl;

--- a/source/SnapDump-Handler/SDBasicHTTPStore.class.st
+++ b/source/SnapDump-Handler/SDBasicHTTPStore.class.st
@@ -14,7 +14,7 @@ SDBasicHTTPStore class >> storeName [
 	^ #http
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : #initialization }
 SDBasicHTTPStore >> applyConfiguration: aConfig [
 	uri := aConfig uri.
    username := aConfig username.
@@ -31,14 +31,8 @@ SDBasicHTTPStore >> client [
 
 { #category : #testing }
 SDBasicHTTPStore >> hasSnapshot: snapshot [
-	^ self hasSnapshot: snapshot snapshotId project: snapshot projectName version: snapshot versionString exception: snapshot exceptionId
-]
-
-{ #category : #testing }
-SDBasicHTTPStore >> hasSnapshot: snapshotId project: projectName version: versionName exception: anExceptionId [
-
 	^ (self client
-		url: (self urlForSnapshot: snapshotId project: projectName version: versionName exception: anExceptionId);
+		url: (self urlForSnapshot: snapshot);
 		head;
 		response) status = 200
 ]
@@ -46,6 +40,16 @@ SDBasicHTTPStore >> hasSnapshot: snapshotId project: projectName version: versio
 { #category : #testing }
 SDBasicHTTPStore >> isSetUp [
 	^ uri notNil
+]
+
+{ #category : #accessing }
+SDBasicHTTPStore >> parametersFor: snapshot [
+
+	^ Dictionary new 
+			at: #projectName put: snapshot projectName;
+			at: #versionName put: snapshot versionString;
+			at: #exceptionId put: snapshot exceptionId;
+			yourself
 ]
 
 { #category : #printing }
@@ -61,12 +65,33 @@ SDBasicHTTPStore >> uri: anUri [
 { #category : #accessing }
 SDBasicHTTPStore >> urlForSnapshot: snapshot [
 
-	^ self urlForSnapshot: snapshot snapshotId project: snapshot projectName version: snapshot versionString exception: snapshot exceptionId
+	^ self urlForSnapshot: snapshot snapshotId  project: snapshot projectName version: snapshot versionString exception:  snapshot exceptionId
+]
+
+{ #category : #accessing }
+SDBasicHTTPStore >> urlForSnapshot: snapshotId parameters: aParameterDictionary [
+	^ (String
+		streamContents: [ :stream | 
+			stream
+				<< (uri / #snapshots / snapshotId) printString;
+				<< '?'.
+			aParameterDictionary keys
+				do: [ :eachParameterName | 
+					stream
+						<< eachParameterName;
+						<< '=';
+						<< (aParameterDictionary at: eachParameterName) urlEncoded ]
+				separatedBy: [ stream << '&' ] ]) asUrl
 ]
 
 { #category : #accessing }
 SDBasicHTTPStore >> urlForSnapshot: snapshotId project: projectName version: versionName exception: anExceptionId [
-	^ uri / #projects / projectName urlEncoded / #versions / versionName urlEncoded / #exceptions / anExceptionId / #snapshots / snapshotId
+	
+	^ self urlForSnapshot: snapshotId parameters: (Dictionary new 
+		at: #projectName put: projectName;
+		at: #versionName put: versionName;
+		at: #exceptionId put: anExceptionId;
+		yourself)
 ]
 
 { #category : #accessing }
@@ -75,7 +100,7 @@ SDBasicHTTPStore >> username: aUsername password: aPassword [
 	password := aPassword
 ]
 
-{ #category : #'as yet unclassified' }
+{ #category : #services }
 SDBasicHTTPStore >> writeSnapshot: snapshot [
 	| writeStream response |
 	writeStream := ByteArray new writeStream.

--- a/source/SnapDump-Handler/SDBasicHTTPStore.class.st
+++ b/source/SnapDump-Handler/SDBasicHTTPStore.class.st
@@ -30,9 +30,15 @@ SDBasicHTTPStore >> client [
 ]
 
 { #category : #testing }
-SDBasicHTTPStore >> hasSnapshotNamed: snapshotId [
+SDBasicHTTPStore >> hasSnapshot: snapshot [
+	^ self hasSnapshot: snapshot snapshotId project: snapshot projectName version: snapshot versionString exception: snapshot exceptionId
+]
+
+{ #category : #testing }
+SDBasicHTTPStore >> hasSnapshot: snapshotId project: projectName version: versionName exception: anExceptionId [
+
 	^ (self client
-		url: (self urlForSnapshot: snapshotId);
+		url: (self urlForSnapshot: snapshotId project: projectName version: versionName exception: anExceptionId);
 		head;
 		response) status = 200
 ]
@@ -53,8 +59,14 @@ SDBasicHTTPStore >> uri: anUri [
 ]
 
 { #category : #accessing }
-SDBasicHTTPStore >> urlForSnapshot: snapshotId [
-	^ uri / #snapshots / snapshotId
+SDBasicHTTPStore >> urlForSnapshot: snapshot [
+
+	^ self urlForSnapshot: snapshot snapshotId project: snapshot projectName version: snapshot versionString exception: snapshot exceptionId
+]
+
+{ #category : #accessing }
+SDBasicHTTPStore >> urlForSnapshot: snapshotId project: projectName version: versionName exception: anExceptionId [
+	^ uri / #projects / projectName urlEncoded / #versions / versionName urlEncoded / #exceptions / anExceptionId / #snapshots / snapshotId
 ]
 
 { #category : #accessing }
@@ -69,7 +81,7 @@ SDBasicHTTPStore >> writeSnapshot: snapshot [
 	writeStream := ByteArray new writeStream.
 	snapshot writeTo: writeStream .
 	response := self client
-		url: (self urlForSnapshot: snapshot id);
+		url: (self urlForSnapshot: snapshot);
 		entity: (ZnByteArrayEntity bytes: writeStream contents);
 		put.
 	Transcript show: 'SnapDump: Error reporting gave response: ', response asString. 

--- a/source/SnapDump-Handler/SDBasicHTTPStore.class.st
+++ b/source/SnapDump-Handler/SDBasicHTTPStore.class.st
@@ -30,14 +30,6 @@ SDBasicHTTPStore >> client [
 ]
 
 { #category : #testing }
-SDBasicHTTPStore >> hasSnapshot: snapshot [
-	^ (self client
-		url: (self urlForSnapshot: snapshot);
-		head;
-		response) status = 200
-]
-
-{ #category : #testing }
 SDBasicHTTPStore >> isSetUp [
 	^ uri notNil
 ]
@@ -57,6 +49,14 @@ SDBasicHTTPStore >> printOn: aStream [
 	aStream << uri asString
 ]
 
+{ #category : #testing }
+SDBasicHTTPStore >> shouldReportSnapshot: snapshot [
+	^ ((self client
+		url: (self urlForSnapshot: snapshot);
+		head;
+		response) status = 200) not
+]
+
 { #category : #accessing }
 SDBasicHTTPStore >> uri: anUri [
 	uri := anUri asZnUrl 
@@ -70,7 +70,14 @@ SDBasicHTTPStore >> urlForSnapshot: snapshot [
 
 { #category : #accessing }
 SDBasicHTTPStore >> urlForSnapshot: snapshotId parameters: aParameterDictionary [
-	^ (String
+	| url |
+	url :=  (uri / #snapshots / snapshotId).
+	aParameterDictionary keysAndValuesDo: [:eachname :eachValue |
+		url queryAt: eachname put: eachValue
+		].
+	^ url
+	
+"	^ (String
 		streamContents: [ :stream | 
 			stream
 				<< (uri / #snapshots / snapshotId) printString;
@@ -81,7 +88,7 @@ SDBasicHTTPStore >> urlForSnapshot: snapshotId parameters: aParameterDictionary 
 						<< eachParameterName;
 						<< '=';
 						<< (aParameterDictionary at: eachParameterName) urlEncoded ]
-				separatedBy: [ stream << '&' ] ]) asUrl
+				separatedBy: [ stream << '&' ] ]) asUrl"
 ]
 
 { #category : #accessing }

--- a/source/SnapDump-Handler/SDHandler.class.st
+++ b/source/SnapDump-Handler/SDHandler.class.st
@@ -48,8 +48,8 @@ SDHandler >> handleSnapshot: snapshot [
 		ifTrue: [
 			Transcript show: 'SnapDump: store is set up'.
 			self store storeSnapshot: (snapshot 
-				project: project;
-				version: version ) ]
+				projectName: project;
+				versionString: version ) ]
 		ifFalse: [ Transcript show: 'tried to store snapshot but store is not set up'; cr ].
 	^ snapshot 
 ]
@@ -66,8 +66,8 @@ SDHandler >> project: anObject [
 
 { #category : #'as yet unclassified' }
 SDHandler >> projectName: projectName versionString: versionString [
-	project := (SDProject name: projectName) store: store.
-	version := (SDVersion string: versionString) project: project
+	self project: projectName.
+	self version: versionString
 ]
 
 { #category : #accessing }

--- a/source/SnapDump-Server-Tests/SDFileTests.class.st
+++ b/source/SnapDump-Server-Tests/SDFileTests.class.st
@@ -19,17 +19,19 @@ SDFileTests >> store [
 SDFileTests >> testSimpleRead [
 	| snapshot |
 	snapshot := self createSimpleSnapshot.
-	self assert: rootPath hasFiles.
-	self assert: snapshot project name equals: 'TestProject'.
-	self assert: snapshot version string equals: '0.1'
+	self deny: rootPath hasFiles.
+	self assert: rootPath hasDirectories.
+	self assert: snapshot projectName equals: 'TestProject'.
+	self assert: snapshot versionString equals: '0.1'
 
 ]
 
 { #category : #tests }
 SDFileTests >> testSimpleWrite [
-	| snapshot |
+	| snapshot root |
 	snapshot := self createSimpleSnapshot.
-	self assert: rootPath hasFiles.
-	self assert: ((rootPath / snapshot id), #snap) exists.
-
+	self deny: rootPath hasFiles.
+	self assert: rootPath hasDirectories.
+	root := self dummySnapshotRootPath.
+	self assert: (root / snapshot snapshotId , #snap) exists
 ]

--- a/source/SnapDump-Server-Tests/SDHTTPTests.class.st
+++ b/source/SnapDump-Server-Tests/SDHTTPTests.class.st
@@ -57,7 +57,7 @@ SDHTTPTests >> tearDown [
 
 { #category : #tests }
 SDHTTPTests >> testInternalServerError [
-	| response snapshot |
+	| response snapshot exceptionId snapshotId |
 	server debugMode: false.
 	response := ZnClient new
 		url: self apiUri / #snapshots / self dummySnapshotId;

--- a/source/SnapDump-Server-Tests/SDHTTPTests.class.st
+++ b/source/SnapDump-Server-Tests/SDHTTPTests.class.st
@@ -23,6 +23,15 @@ SDHTTPTests >> apiUri [
 	^ ('http://', self selfIP, ':', self randomPort asString, '/api') asZnUrl 
 ]
 
+{ #category : #tests }
+SDHTTPTests >> dummySnapshotUrl [
+	^ self apiUri 
+		/ #snapshots / self dummySnapshotId
+		
+	" #projects / self projectNameForTests / #versions
+		/ self versionStringForTests / #exceptions / self dummyExceptionId"
+]
+
 { #category : #accessing }
 SDHTTPTests >> randomPort [
 	^ port ifNil: [
@@ -57,16 +66,17 @@ SDHTTPTests >> tearDown [
 
 { #category : #tests }
 SDHTTPTests >> testInternalServerError [
-	| response snapshot exceptionId snapshotId |
+	| response snapshot |
 	server debugMode: false.
 	response := ZnClient new
-		url: self apiUri / #snapshots / self dummySnapshotId;
-		entity: (ZnByteArrayEntity bytes: '{bogus ;json' asByteArray );
+		url: self dummySnapshotUrl;
+		entity: (ZnByteArrayEntity bytes: '{bogus ;json' asByteArray);
 		put;
 		response.
 	self assert: response isError.
-	self assert: rootPath hasFiles.
-	snapshot := SDFileSnapshot fromFile: rootPath children anyOne.
+	self deny: response code = 404.
+	self assert: rootPath hasDirectories.
+	snapshot := SDFileSnapshot fromFile: rootPath allFiles anyOne.
 	self assert: snapshot className equals: 'NeoJSONReader'
 ]
 
@@ -135,13 +145,15 @@ SDHTTPTests >> testProjectRemove [
 
 { #category : #tests }
 SDHTTPTests >> testSetup [
-	| mock |
+	| mock root |
 	mock := self snapshotMock.
 	self 
 		shouldnt: [ handler handleException: mock ]
 		raise: Error.
-	self assert: rootPath hasFiles.
-	self assert: ((rootPath / mock asSnapshot id), #snap) exists.
+	self assert: rootPath hasDirectories.
+	root := self dummySnapshotRootPath.
+	self assert: root hasFiles.
+	self assert: ((root / mock asSnapshot snapshotId), #snap) exists.
 
 ]
 
@@ -150,12 +162,12 @@ SDHTTPTests >> testSnapshot [
 	| response snapshot |
 	self createSimpleSnapshot.
 	response := ZnClient new
-		url: self apiUri / #snapshots / self dummySnapshotId;
+		url: self dummySnapshotUrl ;
 		get;
 		response.
 	self assert: response isSuccess.
 	snapshot := (NeoJSONReader on: response contents readStream) nextAs: SDSnapshot .
-	self assert: snapshot id equals: self dummySnapshotId .
+	self assert: snapshot snapshotId equals: self dummySnapshotId .
 	
 ]
 
@@ -170,24 +182,27 @@ SDHTTPTests >> testSnapshotList [
 	self assert: response isSuccess equals: true.
 	list := (NeoJSONReader on: response contents readStream) nextListAs: SDSnapshot .
 	self assert: list size equals: 1.
-	self assert: (list first errorSignature) equals: 'Object_printString_ContextWithoutException'
+	self assert: (list first errorSignature) equals: 'TestProject_0.1_Object_printString_ContextWithoutException'
 	
 ]
 
 { #category : #tests }
 SDHTTPTests >> testSnapshotNoVersion [
 	| response snapshot snap json |
-	handler version: ((SDVersion string: '') project: handler project).
+	handler version: ('').
 	snap := self createSimpleSnapshot.
 	self assert: (snap isKindOf: SDMemorySnapshot).
 	response := ZnClient new
-		url: self apiUri / #snapshots / snap id;
+		url: self apiUri
+		/ #snapshots / self dummySnapshotId ;
 		get;
 		response.
 	self assert: response isSuccess.
+	
+
 	snapshot := (NeoJSONReader on: response contents readStream) nextAs: SDSnapshot.
 	json := (NeoJSONReader on: response contents readStream) next.
-	self assert: snapshot id equals: snap id.
+	self assert: snapshot snapshotId equals: snap snapshotId.
 	self deny: (json at: 'versionString') isNil.
 	self deny: (json at: 'versionString') isEmpty.
 	

--- a/source/SnapDump-Server-Tests/SDHTTPTests.class.st
+++ b/source/SnapDump-Server-Tests/SDHTTPTests.class.st
@@ -25,6 +25,15 @@ SDHTTPTests >> apiUri [
 
 { #category : #tests }
 SDHTTPTests >> dummySnapshotUrl [
+	^ (self apiUri / #snapshots / self dummySnapshotId)
+		queryAt: #exceptionId put: self dummyExceptionId;
+		queryAt: 'projectName' put: self projectNameForTests;
+		queryAt: 'versionName' put: self versionStringForTests;
+		yourself
+]
+
+{ #category : #tests }
+SDHTTPTests >> dummySnapshotUrlWithoutProject [
 	^ self apiUri 
 		/ #snapshots / self dummySnapshotId
 		
@@ -123,7 +132,7 @@ SDHTTPTests >> testProjectListEmpty [
 
 { #category : #tests }
 SDHTTPTests >> testProjectNotFound [
-	| response list |
+	| response |
 	response := ZnClient new
 		url: self apiUri / #projects / 'NoneExisting';
 		get;
@@ -158,11 +167,43 @@ SDHTTPTests >> testSetup [
 ]
 
 { #category : #tests }
-SDHTTPTests >> testSnapshot [
+SDHTTPTests >> testSnapshotEmptyVersion [
+	| response  snap  |
+	handler version: ('').
+	snap := self createSimpleSnapshot.
+	self assert: (snap isKindOf: SDMemorySnapshot).
+	response := ZnClient new
+		url: self apiUri
+		/ #snapshots / self dummySnapshotId ;
+		get;
+		response.
+	self deny: response isSuccess.
+	self assert: response code = 404
+	
+
+	
+]
+
+{ #category : #tests }
+SDHTTPTests >> testSnapshotGet [
 	| response snapshot |
 	self createSimpleSnapshot.
 	response := ZnClient new
 		url: self dummySnapshotUrl ;
+		get;
+		response.
+	self assert: response isSuccess.
+	snapshot := (NeoJSONReader on: response contents readStream) nextAs: SDSnapshot .
+	self assert: snapshot snapshotId equals: self dummySnapshotId .
+	
+]
+
+{ #category : #tests }
+SDHTTPTests >> testSnapshotGetById [
+	| response snapshot |
+	self createSimpleSnapshot.
+	response := ZnClient new
+		url: self dummySnapshotUrlWithoutProject ;
 		get;
 		response.
 	self assert: response isSuccess.
@@ -187,25 +228,18 @@ SDHTTPTests >> testSnapshotList [
 ]
 
 { #category : #tests }
-SDHTTPTests >> testSnapshotNoVersion [
-	| response snapshot snap json |
-	handler version: ('').
-	snap := self createSimpleSnapshot.
-	self assert: (snap isKindOf: SDMemorySnapshot).
+SDHTTPTests >> testSnapshotPutIdOnly [
+	| response |
+	server debugMode: false.
 	response := ZnClient new
-		url: self apiUri
-		/ #snapshots / self dummySnapshotId ;
-		get;
+		url: self dummySnapshotUrlWithoutProject;
+		entity: (ZnByteArrayEntity bytes: '{bogus ;json' asByteArray);
+		put;
 		response.
-	self assert: response isSuccess.
-	
-
-	snapshot := (NeoJSONReader on: response contents readStream) nextAs: SDSnapshot.
-	json := (NeoJSONReader on: response contents readStream) next.
-	self assert: snapshot snapshotId equals: snap snapshotId.
-	self deny: (json at: 'versionString') isNil.
-	self deny: (json at: 'versionString') isEmpty.
-	
+	self assert: response isError.
+	self assert: response code = 400.
+	self assert: (response entity string includesSubstring: 'MissingParameter').
+	self deny: rootPath hasDirectories.
 ]
 
 { #category : #tests }

--- a/source/SnapDump-Server/SDOpenAPICall.class.st
+++ b/source/SnapDump-Server/SDOpenAPICall.class.st
@@ -30,8 +30,8 @@ SDOpenAPICall >> projectNamed: projectName versionAt: versionString [
 ]
 
 { #category : #public }
-SDOpenAPICall >> snapshotWithId: aString [ 
-	[ ^ self store snapshotWithId: aString ]
+SDOpenAPICall >> snapshotWithId: aString project: aProjectString version: aVersionString [
+	[ ^ self store snapshotWithId: aString project: aProjectString version: aVersionString]
 		on: NotFound 
 		do: [ :err |
 			ZnRespond signalWith: (ZnResponse notFound: request url) ]

--- a/source/SnapDump-Server/SDOpenAPICall.class.st
+++ b/source/SnapDump-Server/SDOpenAPICall.class.st
@@ -30,8 +30,8 @@ SDOpenAPICall >> projectNamed: projectName versionAt: versionString [
 ]
 
 { #category : #public }
-SDOpenAPICall >> snapshotWithId: aString [
-	[ ^ self store snapshotWithId: aString ]
+SDOpenAPICall >> snapshotWithId: aString project: aProjectName version: aVersionName exceptionId: anExceptionId [
+	[ ^ self store snapshotWithId: aString project: aProjectName version: aVersionName exceptionId: anExceptionId ]
 		on: NotFound 
 		do: [ :err |
 			ZnRespond signalWith: (ZnResponse notFound: request url) ]

--- a/source/SnapDump-Server/SDOpenAPICall.class.st
+++ b/source/SnapDump-Server/SDOpenAPICall.class.st
@@ -30,8 +30,8 @@ SDOpenAPICall >> projectNamed: projectName versionAt: versionString [
 ]
 
 { #category : #public }
-SDOpenAPICall >> snapshotWithId: aString project: aProjectName version: aVersionName exceptionId: anExceptionId [
-	[ ^ self store snapshotWithId: aString project: aProjectName version: aVersionName exceptionId: anExceptionId ]
+SDOpenAPICall >> snapshotWithId: aString [ 
+	[ ^ self store snapshotWithId: aString ]
 		on: NotFound 
 		do: [ :err |
 			ZnRespond signalWith: (ZnResponse notFound: request url) ]

--- a/source/SnapDump-Server/SDProjectListCall.class.st
+++ b/source/SnapDump-Server/SDProjectListCall.class.st
@@ -11,6 +11,6 @@ SDProjectListCall class >> path [
 
 { #category : #public }
 SDProjectListCall >> get [
-	self jsonResponse: self store projects values. 
+	self jsonResponse: self store projects. 
 	
 ]

--- a/source/SnapDump-Server/SDSnapshotCall.class.st
+++ b/source/SnapDump-Server/SDSnapshotCall.class.st
@@ -18,6 +18,7 @@ SDSnapshotCall class >> parameterExceptionId [
 		in: #query;
 		beString;
 		required: false;
+		allowEmptyValue: false;
 		description: 'Identify a given exception within the context of this server. Several snapshots can be reported for a same exceptionId'
 
 ]
@@ -30,7 +31,7 @@ SDSnapshotCall class >> parameterProjectName [
 		in: #query;
 		beString;
 		required: false;
-		allowEmptyValue: true;
+		allowEmptyValue: false;
 		description: 'Name of the project to which a snapshot belongs to'
 
 ]
@@ -54,8 +55,8 @@ SDSnapshotCall class >> parameterVersionName [
 		name: 'versionName';
 		in: #query;
 		beString;
-		allowEmptyValue: true;
 		required: false;
+		allowEmptyValue: false;
 		description: 'Version of the project to which a snapshot belongs to'
 
 ]
@@ -95,16 +96,28 @@ SDSnapshotCall >> get [
 { #category : #accessing }
 SDSnapshotCall >> head [
 
-	response := (self store hasSnapshotId: snapshotId exceptionId: exceptionId )
-		ifTrue: [ ZnResponse ok: (ZnStringEntity text: 'OK') ]
-		ifFalse: [ ZnResponse notFound: request uri ]
+	self validateRequiredParameters: #(exceptionId projectName versionName).
+	[ self snapshot ]
+		on: NotFound
+		do: [ :ex | 
+			(self store
+				shouldReportProject: projectName
+				version: versionName
+				exception: exceptionId)
+				ifTrue: [ ^ ZnResponse notFound: request uri ] ].
+	ZnResponse ok: (ZnStringEntity text: 'OK')
 ]
 
 { #category : #public }
 SDSnapshotCall >> put [
-| snapshot |
+| snapshot dict |
 
-	[snapshot := self store buildSnapshotFrom: request contents readStream project: projectName version: versionName.
+	self validateRequiredParameters: #(projectName versionName exceptionId).
+	[
+	snapshot := self store buildSnapshot: snapshotId exception: exceptionId project: projectName version: versionName.
+	"still need to read the meta data to get all variables initialized before being written on disk "
+	dict := SDFileSnapshot readMetaFrom: request contents readStream.
+	snapshot initializeMeta: dict.
 	snapshot validate]
 	on: ZnCharacterEncodingError  
 	do: [:err | 
@@ -117,5 +130,25 @@ SDSnapshotCall >> put [
 
 { #category : #public }
 SDSnapshotCall >> snapshot [
-	^ self snapshotWithId: snapshotId
+	[ (projectName isNil or: [ versionName isNil ])
+		ifTrue: [ 
+			"here we give the possibility to fetch a given snapshot from its snapshotId only.
+			handy but slower than fetching with a known project and version "
+			^ self store snapshotWithId: snapshotId ].
+	^ self store
+		snapshotWithId: snapshotId
+		project: projectName
+		version: versionName ]
+		on: NotFound
+		do: [ :err | ZnRespond signalWith: (ZnResponse notFound: request url) ]
+]
+
+{ #category : #public }
+SDSnapshotCall >> validateRequiredParameters: aCollectionOfParameterNames [
+
+ 	aCollectionOfParameterNames do: [ :eachParameterName |
+		(self instVarNamed: eachParameterName) isEmptyOrNil ifTrue: [ 
+			OAMissingRequiredParameter signal: 'parameter ' , eachParameterName , ' is required but not present'
+			 ]
+		 ]
 ]

--- a/source/SnapDump-Server/SDSnapshotCall.class.st
+++ b/source/SnapDump-Server/SDSnapshotCall.class.st
@@ -2,10 +2,37 @@ Class {
 	#name : #SDSnapshotCall,
 	#superclass : #SDOpenAPICall,
 	#instVars : [
-		'snapshotId'
+		'snapshotId',
+		'projectName',
+		'versionName',
+		'exceptionId'
 	],
 	#category : #'SnapDump-Server-REST'
 }
+
+{ #category : #accessing }
+SDSnapshotCall class >> parameterExceptionId [
+	<openApiParameter: #( common )>
+	^ OAParameter new
+		name: 'exceptionId';
+		in: #path;
+		beString;
+		required: true;
+		description: 'An exception unique id within the outter project-version context. Several snapshots can be reported for a single exceptionId'
+
+]
+
+{ #category : #accessing }
+SDSnapshotCall class >> parameterProjectName [
+	<openApiParameter: #( common )>
+	^ OAParameter new
+		name: 'projectName';
+		in: #path;
+		beString;
+		required: true;
+		description: 'Name of the project to which a snapshot belongs to'
+
+]
 
 { #category : #accessing }
 SDSnapshotCall class >> parameterSnapshotId [
@@ -15,18 +42,30 @@ SDSnapshotCall class >> parameterSnapshotId [
 		in: #path;
 		beString;
 		required: true;
-		description: 'Snapshot with unique id'
+		description: 'Snapshot with unique id within the outter project-version-exception context'
+
+]
+
+{ #category : #accessing }
+SDSnapshotCall class >> parameterVersionName [
+	<openApiParameter: #( common )>
+	^ OAParameter new
+		name: 'versionName';
+		in: #path;
+		beString;
+		required: true;
+		description: 'Version of the project to which a snapshot belongs to'
 
 ]
 
 { #category : #accessing }
 SDSnapshotCall class >> path [
-	^ '/snapshots/{snapshotId}'
+	^ 'projects/{projectName}/versions/{versionName}/exceptions/{exceptionId}/snapshots/{snapshotId}'
 ]
 
 { #category : #'submorphs-add/remove' }
 SDSnapshotCall >> delete [
-	[self store removeSnapshotWithId: snapshotId]
+	[self store removeSnapshotWithId: snapshotId project: projectName version: versionName exception: exceptionId]
 		on: FileDoesNotExistException 
 		do: [ :err | ^ response := ZnResponse notFound: request uri ] .
 	response := ZnResponse ok: (ZnStringEntity text: 'OK') 
@@ -53,7 +92,7 @@ SDSnapshotCall >> get [
 
 { #category : #accessing }
 SDSnapshotCall >> head [
-	response := (self store hasSnapshotNamed: snapshotId)
+	response := (self store hasSnapshot: snapshotId project: projectName version: versionName exception: exceptionId)
 		ifTrue: [ ZnResponse ok: (ZnStringEntity text: 'OK') ]
 		ifFalse: [ ZnResponse notFound: request uri ]
 ]
@@ -61,7 +100,7 @@ SDSnapshotCall >> head [
 { #category : #public }
 SDSnapshotCall >> put [
 | snapshot |
-	[snapshot := self store buildSnapshotFrom: request contents readStream.
+	[snapshot := self store buildSnapshotFrom: request contents readStream project: projectName version: versionName.
 	snapshot sanitize.
 	snapshot validate]
 	on: ZnCharacterEncodingError  
@@ -75,5 +114,5 @@ SDSnapshotCall >> put [
 
 { #category : #public }
 SDSnapshotCall >> snapshot [
-	^ self snapshotWithId: snapshotId 
+	^ self snapshotWithId: snapshotId  project: projectName version: versionName exceptionId: exceptionId
 ]

--- a/source/SnapDump-Server/SDSnapshotCall.class.st
+++ b/source/SnapDump-Server/SDSnapshotCall.class.st
@@ -15,10 +15,10 @@ SDSnapshotCall class >> parameterExceptionId [
 	<openApiParameter: #( common )>
 	^ OAParameter new
 		name: 'exceptionId';
-		in: #path;
+		in: #query;
 		beString;
-		required: true;
-		description: 'An exception unique id within the outter project-version context. Several snapshots can be reported for a single exceptionId'
+		required: false;
+		description: 'Identify a given exception within the context of this server. Several snapshots can be reported for a same exceptionId'
 
 ]
 
@@ -27,9 +27,10 @@ SDSnapshotCall class >> parameterProjectName [
 	<openApiParameter: #( common )>
 	^ OAParameter new
 		name: 'projectName';
-		in: #path;
+		in: #query;
 		beString;
-		required: true;
+		required: false;
+		allowEmptyValue: true;
 		description: 'Name of the project to which a snapshot belongs to'
 
 ]
@@ -42,7 +43,7 @@ SDSnapshotCall class >> parameterSnapshotId [
 		in: #path;
 		beString;
 		required: true;
-		description: 'Snapshot with unique id within the outter project-version-exception context'
+		description: 'Identify a given snapshot within the context of this server'
 
 ]
 
@@ -51,21 +52,22 @@ SDSnapshotCall class >> parameterVersionName [
 	<openApiParameter: #( common )>
 	^ OAParameter new
 		name: 'versionName';
-		in: #path;
+		in: #query;
 		beString;
-		required: true;
+		allowEmptyValue: true;
+		required: false;
 		description: 'Version of the project to which a snapshot belongs to'
 
 ]
 
 { #category : #accessing }
 SDSnapshotCall class >> path [
-	^ 'projects/{projectName}/versions/{versionName}/exceptions/{exceptionId}/snapshots/{snapshotId}'
+	^ '/snapshots/{snapshotId}'
 ]
 
 { #category : #'submorphs-add/remove' }
 SDSnapshotCall >> delete [
-	[self store removeSnapshotWithId: snapshotId project: projectName version: versionName exception: exceptionId]
+	[self store removeSnapshot: self snapshot]
 		on: FileDoesNotExistException 
 		do: [ :err | ^ response := ZnResponse notFound: request uri ] .
 	response := ZnResponse ok: (ZnStringEntity text: 'OK') 
@@ -92,7 +94,8 @@ SDSnapshotCall >> get [
 
 { #category : #accessing }
 SDSnapshotCall >> head [
-	response := (self store hasSnapshot: snapshotId project: projectName version: versionName exception: exceptionId)
+
+	response := (self store hasSnapshotId: snapshotId exceptionId: exceptionId )
 		ifTrue: [ ZnResponse ok: (ZnStringEntity text: 'OK') ]
 		ifFalse: [ ZnResponse notFound: request uri ]
 ]
@@ -100,8 +103,8 @@ SDSnapshotCall >> head [
 { #category : #public }
 SDSnapshotCall >> put [
 | snapshot |
+
 	[snapshot := self store buildSnapshotFrom: request contents readStream project: projectName version: versionName.
-	snapshot sanitize.
 	snapshot validate]
 	on: ZnCharacterEncodingError  
 	do: [:err | 
@@ -114,5 +117,5 @@ SDSnapshotCall >> put [
 
 { #category : #public }
 SDSnapshotCall >> snapshot [
-	^ self snapshotWithId: snapshotId  project: projectName version: versionName exceptionId: exceptionId
+	^ self snapshotWithId: snapshotId
 ]


### PR DESCRIPTION
Once again, it looks (and it got) bigger that what I had in mind when starting to move things! sorry for that :(

At the end, here are the changes that this PR would introduce:

1) A snapshot would have a #snapshotId and an #exceptionId
The #exceptionId identify a specific exception reported by SnapDump (what was previously the #id)
The #snapshotId identify a specific snapshot being registered for a given exception. Several #snapshotId can be associated to the same #exceptionId

The intention is to be able to collect several snapshots for a similar exception occuring at different point in time.
With a limit  on server side on the number of snapshot that can be registered for a same #exceptionId.
This could give information about the frequency of a given exception.
Maybe later some specific context information could be reported within each snapshot.



2) I kept the concept of #snapshotId and snapshot calls with a single path parameter.
I think it would still be handy to perform some server queries with just an id.
And anyway the server perform a lot of actions in a "flat way": 
it iterates on a memory list of snapshots, that gets reset on each addition / removal. 
I understand that all snapshots should always be "manageable" in memory, as snapdump is not intended to archive snapshots. 

3) The handler is no longer initialized with project and version objects, but just project name and version strings.
The snapshots generated by handler also point to a simple project name and version string (project and version objects are left nil).
This goes in the direction of having a handler as simple as possible, not depending from the snapdump model

4) The snapshot call would have some optional query parameters: #projectName #versionName #exceptionId
They are currently used by the #put and #head actions
Doing that way makes it easier to build dynamic url (on handler side) with possible empty values for projectName and versionName.
It also feels more flexible than requiring path parameters for any http method. 

The server decides how he wants to manage empty project and version values. He is the only one that has to deal with default project and version names.
(Currently this change has limited interest regarding version and project parameters, as these ones could already be read from meta information). 

5) The file structure on server side has changed from flat to a project dir => version dir => snapshot file structure.
Right now there is no actual benefit with this change, as most of the actions are taking advantages of the snapshot memory list.
But it feels natural without adding much complexity.
 

All the tests are green and the examples work fine.


Here are a list of plans / "useful" idea that I had in mind while working on that.
Feel free to tell me if it goes totally out of scope :)

- update the UI to take advantage of the #exceptionId concept.
I guess I would start with an extra column to group snapshots from a same exception id.
Also having the ability to remove all snapshot from a same exceptionId.

- attach a "textual" stack trace to the snapshot generated by the handler.
It would be nice to still be able to take advantage of snapshots without having the exact same image context that the reported exception.
The UI could offer to display / download stack traces for a given snapshot.

- I am not sure how to do that without making snapdump too specific, but it would nice if we could also plug and attach some "log extracts" to the snap dump generated by the handler.
In our case, we could for example have access to last 30 lines of the application log before the exception occured.
From times to times, such logs context could help understand.
And managing docker container logs is a pain :)

- A minimal seaside interface for the server image ? 
This would give a quick overview of to the current reported snapshot without having to load and open snapdump in our local images.
And such information like stack-traces or logs could already be accessible from this interface ?