### PR TITLE
Use Iceberg description

### DIFF
--- a/source/SnapDump-Server/SDServer.class.st
+++ b/source/SnapDump-Server/SDServer.class.st
@@ -27,6 +27,13 @@ SDServer class >> port: aNumber path: aFileReference [
 		yourself
 ]
 
+{ #category : #accessing }
+SDServer class >> repositoryDescription [
+	| snapDumpRepo |
+	snapDumpRepo := IceRepository registry detect: [ :each | each name = 'SnapDump' ].
+	^ snapDumpRepo head description
+]
+
 { #category : #'as yet unclassified' }
 SDServer class >> startOnPort: aNumber path: aFileReference [
 	^ self instance 

--- a/source/SnapDump-Server/SDServerVersionCall.class.st
+++ b/source/SnapDump-Server/SDServerVersionCall.class.st
@@ -1,0 +1,18 @@
+Class {
+	#name : #SDServerVersionCall,
+	#superclass : #SDOpenAPICall,
+	#category : #'SnapDump-Server-REST'
+}
+
+{ #category : #accessing }
+SDServerVersionCall class >> path [
+	^ '/version'
+]
+
+{ #category : #public }
+SDServerVersionCall >> get [	
+	response := ZnResponse ok: (
+		ZnEntity 
+			with: SDServer repositoryDescription
+			type: ZnMimeType applicationJson setCharSetUTF8)
+]


### PR DESCRIPTION
About having a build version handler requested in #10 would it be something along this ?
Using the last commit description method from IceCommit should give us the tag as a string in a case of a released server.

I suppose there are other solutions using the environment variable to set it to SnapDump while starting the server at deployment...