### PR TITLE
issue #25: API urls should contain version id

### DIFF
--- a/source/SnapDump-Core/SDSnapshot.class.st
+++ b/source/SnapDump-Core/SDSnapshot.class.st
@@ -21,6 +21,18 @@ Class {
 	#category : #'SnapDump-Core'
 }
 
+{ #category : #accessing }
+SDSnapshot class >> apiVersion [
+
+	"A version description that is used by all parts (handler, server, client) to ensure consistent API calls 
+	(for example, avoid pushing snaphots to an incompatible version of snapdump server).
+	We use the class side of SDSnapshot as it is accessible from all kind of images (handler, server, client).
+	This description is expected to be updated each time 'breaking' changes are introduced on server side.
+	It will be used as an URL prefix"
+	
+	^ 'v2'
+]
+
 { #category : #'as yet unclassified' }
 SDSnapshot class >> exception: anException [
 	^ self new exception: anException

--- a/source/SnapDump-Handler/SDBasicHTTPStore.class.st
+++ b/source/SnapDump-Handler/SDBasicHTTPStore.class.st
@@ -51,7 +51,7 @@ SDBasicHTTPStore >> printOn: aStream [
 
 { #category : #accessing }
 SDBasicHTTPStore >> uri: anUri [
-	uri := anUri asZnUrl 
+	uri := anUri asZnUrl / SDSnapshot apiVersion
 ]
 
 { #category : #accessing }

--- a/source/SnapDump-Server-Tests/SDHTTPTests.class.st
+++ b/source/SnapDump-Server-Tests/SDHTTPTests.class.st
@@ -9,16 +9,6 @@ Class {
 }
 
 { #category : #accessing }
-SDHTTPTests >> apiHandler [		
-	^ ZnPrefixMappingDelegate new 
-		map: 'api' 
-		to: (SDServerDelegate new
-			store: self filesystemStore;
-			uriSpace: (OpenAPIUriSpace new
-				rootClass: SDOpenAPICall))
-]
-
-{ #category : #accessing }
 SDHTTPTests >> apiUri [
 	^ ('http://', self selfIP, ':', self randomPort asString, '/api') asZnUrl 
 ]
@@ -51,10 +41,9 @@ SDHTTPTests >> selfIP [
 { #category : #running }
 SDHTTPTests >> setUp [ 
 	super setUp.
-	server := (ZnServer on: self randomPort)
-		delegate: self apiHandler;
-		debugMode: true;
-		start.
+	server := SDServer port: self randomPort path: rootPath.
+	server debugMode: true.
+	server start.
 	"SnapDump current stub store willReturn: store."
 ]
 
@@ -72,7 +61,7 @@ SDHTTPTests >> tearDown [
 { #category : #tests }
 SDHTTPTests >> testInternalServerError [
 	| response snapshot |
-	server debugMode: false.
+	server znServer debugMode: false.
 	response := ZnClient new
 		url: self dummySnapshotUrl;
 		entity: (ZnByteArrayEntity bytes: '{bogus ;json' asByteArray);

--- a/source/SnapDump-Server-Tests/SDHTTPTests.class.st
+++ b/source/SnapDump-Server-Tests/SDHTTPTests.class.st
@@ -13,14 +13,20 @@ SDHTTPTests >> apiUri [
 	^ ('http://', self selfIP, ':', self randomPort asString, '/api') asZnUrl 
 ]
 
+{ #category : #accessing }
+SDHTTPTests >> apiVersionedUri [
+
+	^ self apiUri / SDSnapshot apiVersion
+]
+
 { #category : #tests }
 SDHTTPTests >> dummySnapshotUrl [
-	^ (self apiUri /#projects / self projectNameForTests / #versions / self versionStringForTests / #exceptions / self dummyExceptionId / #snapshots / self dummySnapshotId)
+	^ (self apiVersionedUri /#projects / self projectNameForTests / #versions / self versionStringForTests / #exceptions / self dummyExceptionId / #snapshots / self dummySnapshotId)
 ]
 
 { #category : #tests }
 SDHTTPTests >> dummySnapshotUrlWithoutProject [
-	^ self apiUri 
+	^ self apiVersionedUri 
 		/ #snapshots / self dummySnapshotId
 		
 	" #projects / self projectNameForTests / #versions
@@ -82,7 +88,7 @@ SDHTTPTests >> testProject [
 	| response project |
 	self createSimpleSnapshot.
 	response := ZnClient new
-		url: self apiUri / #projects / #TestProject;
+		url: self apiVersionedUri / #projects / #TestProject;
 		get;
 		response.
 	self assert: response isSuccess.
@@ -96,7 +102,7 @@ SDHTTPTests >> testProjectList [
 	| response list |
 	self createSimpleSnapshot.
 	response := ZnClient new
-		url: self apiUri / #projects;
+		url: self apiVersionedUri / #projects;
 		get;
 		response.
 	self assert: response isSuccess equals: true.
@@ -110,7 +116,7 @@ SDHTTPTests >> testProjectList [
 SDHTTPTests >> testProjectListEmpty [
 	| response list |
 	response := ZnClient new
-		url: self apiUri / #projects;
+		url: self apiVersionedUri / #projects;
 		get;
 		response.
 	self assert: response isSuccess equals: true.
@@ -122,7 +128,7 @@ SDHTTPTests >> testProjectListEmpty [
 SDHTTPTests >> testProjectNotFound [
 	| response |
 	response := ZnClient new
-		url: self apiUri / #projects / 'NoneExisting';
+		url: self apiVersionedUri / #projects / 'NoneExisting';
 		get;
 		response.
 	self assert: response status = 404.
@@ -133,7 +139,7 @@ SDHTTPTests >> testProjectNotFound [
 SDHTTPTests >> testProjectRemove [
 	| response |
 	response := ZnClient new
-		url: self apiUri / #projects / 'NoneExisting';
+		url: self apiVersionedUri / #projects / 'NoneExisting';
 		delete;
 		response.
 	self assert: response status = 405.
@@ -198,7 +204,7 @@ SDHTTPTests >> testSnapshotList [
 	| response list |
 	self createSimpleSnapshot.
 	response := ZnClient new
-		url: self apiUri / #projects / #TestProject / #versions / '0.1' / #exceptions / self dummyExceptionId / #snapshots;
+		url: self apiVersionedUri / #projects / #TestProject / #versions / '0.1' / #exceptions / self dummyExceptionId / #snapshots;
 		get;
 		response.
 	self assert: response isSuccess equals: true.
@@ -212,7 +218,7 @@ SDHTTPTests >> testSnapshotList [
 SDHTTPTests >> testSpec [
 	| response |
 	response := ZnClient new
-		url: self apiUri / #spec;
+		url: self apiVersionedUri / #spec;
 		get;
 		response.
 	self assert: response isSuccess equals: true.
@@ -226,7 +232,7 @@ SDHTTPTests >> testVersion [
 	| response version |
 	self createSimpleSnapshot.
 	response := ZnClient new
-		url: self apiUri / #projects / #TestProject / #versions / #'0.1';
+		url: self apiVersionedUri / #projects / #TestProject / #versions / #'0.1';
 		get;
 		response.
 	self assert: response isSuccess equals: true.
@@ -240,7 +246,7 @@ SDHTTPTests >> testVersionList [
 	| response list |
 	self createSimpleSnapshot.
 	response := ZnClient new
-		url: self apiUri / #projects / #TestProject / #versions ;
+		url: self apiVersionedUri / #projects / #TestProject / #versions ;
 		get;
 		response.
 	self assert: response isSuccess equals: true.

--- a/source/SnapDump-Server/SDServer.class.st
+++ b/source/SnapDump-Server/SDServer.class.st
@@ -79,7 +79,7 @@ SDServer >> port: aNumber [
 { #category : #accessing }
 SDServer >> serverDelegate [
 	^ ZnPrefixMappingDelegate new 
-		map: 'api' to: self apiHandler;
+		map: ('api/' , SDSnapshot apiVersion) to: self apiHandler;
 		map: 'health' to: ZnTestRunnerDelegate new.
 
 ]

--- a/source/SnapDump-Server/SDServer.class.st
+++ b/source/SnapDump-Server/SDServer.class.st
@@ -4,7 +4,8 @@ Class {
 	#instVars : [
 		'port',
 		'server',
-		'path'
+		'path',
+		'debugMode'
 	],
 	#classInstVars : [
 		'instance',
@@ -67,6 +68,18 @@ SDServer >> apiHandler [
 ]
 
 { #category : #accessing }
+SDServer >> debugMode [
+
+	^ debugMode ifNil: [ false ]
+]
+
+{ #category : #accessing }
+SDServer >> debugMode: aBoolean [
+
+	debugMode := aBoolean
+]
+
+{ #category : #accessing }
 SDServer >> path: anObject [
 	path := anObject
 ]
@@ -78,10 +91,13 @@ SDServer >> port: aNumber [
 
 { #category : #accessing }
 SDServer >> serverDelegate [
-	^ ZnPrefixMappingDelegate new 
-		map: ('api/' , SDSnapshot apiVersion) to: self apiHandler;
-		map: 'health' to: ZnTestRunnerDelegate new.
-
+	^ ZnPrefixMappingDelegate new
+		map: 'api'
+			to:
+			(ZnPrefixMappingDelegate new
+				map: SDSnapshot apiVersion
+				to: self apiHandler);
+		map: 'health' to: ZnTestRunnerDelegate new
 ]
 
 { #category : #accessing }
@@ -89,10 +105,18 @@ SDServer >> start [
 				
 	server := (ZnServer on: port)
 		delegate: self serverDelegate;
+		debugMode: self debugMode;
 		start.
 ]
 
 { #category : #accessing }
 SDServer >> stop [ 
 	server stop
+]
+
+{ #category : #'accessing - tests' }
+SDServer >> znServer [
+	"for test purposes"
+	
+	^ server
 ]

--- a/source/SnapDump-Server/SDServerDelegate.class.st
+++ b/source/SnapDump-Server/SDServerDelegate.class.st
@@ -7,6 +7,12 @@ Class {
 	#category : #'SnapDump-Server-REST'
 }
 
+{ #category : #accessing }
+SDServerDelegate >> handlerRequest: aRequest [
+
+	^ super handleRequest: aRequest
+]
+
 { #category : #'error handling' }
 SDServerDelegate >> serverError: request exception: exception [
 	

--- a/source/SnapDump-Server/SDServerDelegate.class.st
+++ b/source/SnapDump-Server/SDServerDelegate.class.st
@@ -7,12 +7,6 @@ Class {
 	#category : #'SnapDump-Server-REST'
 }
 
-{ #category : #accessing }
-SDServerDelegate >> handlerRequest: aRequest [
-
-	^ super handleRequest: aRequest
-]
-
 { #category : #'error handling' }
 SDServerDelegate >> serverError: request exception: exception [
 	


### PR DESCRIPTION
Fix proposal for issue #25 

Now managing a api version id,
expected as an url prefix,
automatically added by handler images.

Having the version id coded in the image and automatically used by all parts (handler / server) would prevent from inconsistent API calls
Just an idea, tell me what you think.

On the other hand, it would not solve the idea of running multiple snapdump servers with the same version. 
In such a case, having the version id configured outside the image would be more flexible