### PR TITLE
Issue 27 attach textual stack trace to snapshots

### DIFF
--- a/source/SnapDump-Client/SDHTTPStore.class.st
+++ b/source/SnapDump-Client/SDHTTPStore.class.st
@@ -121,6 +121,15 @@ SDHTTPStore >> snapshotDumpFor: aSnapshot [
 		get
 ]
 
+{ #category : #accessing }
+SDHTTPStore >> snapshotStackFor: aSnapshot [ 
+
+	^ (self client
+		headerAt: 'Accept' put: 'application/X-SnapDump-Stack';
+		url: (self urlForSnapshot: aSnapshot);
+		get) utf8Decoded
+]
+
 { #category : #'services - getting' }
 SDHTTPStore >> snapshotsOfException: anException [ 
 	| response |

--- a/source/SnapDump-Client/SDHTTPStore.class.st
+++ b/source/SnapDump-Client/SDHTTPStore.class.st
@@ -116,7 +116,7 @@ SDHTTPStore >> shouldReportSnapshot: snapshot [
 { #category : #accessing }
 SDHTTPStore >> snapshotDumpFor: aSnapshot [ 
 	^ self client
-		headerAt: 'Accept' put: 'application/X-SnapDump-Fuel';
+		headerAt: 'Accept' put: SDStore mimeTypeFuel;
 		url: (self urlForSnapshot: aSnapshot);
 		get
 ]
@@ -125,7 +125,7 @@ SDHTTPStore >> snapshotDumpFor: aSnapshot [
 SDHTTPStore >> snapshotStackFor: aSnapshot [ 
 
 	^ (self client
-		headerAt: 'Accept' put: 'application/X-SnapDump-Stack';
+		headerAt: 'Accept' put: SDStore mimeTypeStack;
 		url: (self urlForSnapshot: aSnapshot);
 		get) utf8Decoded
 ]

--- a/source/SnapDump-Core/SDFileSnapshot.class.st
+++ b/source/SnapDump-Core/SDFileSnapshot.class.st
@@ -80,11 +80,23 @@ SDFileSnapshot >> setFuelHeader: aFLHeader [
 ]
 
 { #category : #'as yet unclassified' }
+SDFileSnapshot >> stackTraceStream [
+	^ file binaryReadStream
+		upTo: self class metaSeparator;
+		upTo: self class metaSeparator;
+		yourself
+]
+
+{ #category : #'as yet unclassified' }
 SDFileSnapshot >> storeRaw: aByteArray [
 	"write file with new json header in case the fields have been changed"
+	| snapshotParts |
+	snapshotParts := (aByteArray splitOn: self class metaSeparator).
 	file binaryWriteStream 
 		nextPutAll: (NeoJSONWriter toString: self) utf8Encoded;  
 		nextPut: self class metaSeparator;
-		nextPutAll: (aByteArray copyFrom: ((aByteArray indexOf: self class metaSeparator) + 1) to: aByteArray size );
+		nextPutAll: snapshotParts second;
+		nextPut: self class metaSeparator;
+		nextPutAll: snapshotParts third;
 		close
 ]

--- a/source/SnapDump-Core/SDMemorySnapshot.class.st
+++ b/source/SnapDump-Core/SDMemorySnapshot.class.st
@@ -48,13 +48,15 @@ SDMemorySnapshot >> serializeContext: aContext on: stream [
 SDMemorySnapshot >> setContext: aContext exceptionClassName: exceptionClassName [
 	| method |
 	context := aContext.
+	self
+		stackTrace:
+			(String streamContents: [ :stream | context errorReportOn: stream ]).
 	method := context sender method.
 	self
 		exception:
 			(SDException new
 				initializeFromClassName: exceptionClassName method: method;
-				yourself).
-	
+				yourself)
 ]
 
 { #category : #initialization }
@@ -71,5 +73,8 @@ SDMemorySnapshot >> writeTo: stream [
 	stream nextPut: self class metaSeparator.
 	self 
 		serializeContext: context 
-		on: stream 
+		on: stream.
+	stream nextPut: self class metaSeparator.
+	stream nextPutAll: (self stackTrace) utf8Encoded 
+		 
 ]

--- a/source/SnapDump-Core/SDSnapshot.class.st
+++ b/source/SnapDump-Core/SDSnapshot.class.st
@@ -16,7 +16,8 @@ Class {
 		'exceptionId',
 		'versionString',
 		'projectName',
-		'exception'
+		'exception',
+		'stackTrace'
 	],
 	#category : #'SnapDump-Core'
 }
@@ -50,7 +51,7 @@ SDSnapshot >> asSnapshot [
 
 { #category : #private }
 SDSnapshot >> basicMetaFields [
-	^ #(projectName versionString snapshotId exceptionId timestamp className selector exceptionClass operatingSystem systemArchitecture operatingSystemVersion vmVersion imageVersion imageBuild)
+	^ #(projectName versionString  exceptionId timestamp className selector exceptionClass operatingSystem systemArchitecture operatingSystemVersion vmVersion imageVersion imageBuild)
 ]
 
 { #category : #private }
@@ -73,12 +74,6 @@ SDSnapshot >> dateAndTimeString [
 { #category : #accessing }
 SDSnapshot >> dateString [ 
 	^ timestamp asDate printFormat: #(1 2 3 $. 1 1)
-]
-
-{ #category : #private }
-SDSnapshot >> encodeMetaOn: aSerializer [
-	self metaFields do: [ :field |
-		aSerializer at: field putAdditionalObject: (self perform: field asSymbol) ]
 ]
 
 { #category : #initialization }
@@ -272,6 +267,18 @@ SDSnapshot >> snapshotSignature [
 		stream 
 			<< '_'
 			<< timestamp printString ]
+]
+
+{ #category : #accessing }
+SDSnapshot >> stackTrace [
+
+	^ stackTrace
+]
+
+{ #category : #accessing }
+SDSnapshot >> stackTrace: aString [
+
+	stackTrace := aString
 ]
 
 { #category : #accessing }

--- a/source/SnapDump-Core/SDStore.class.st
+++ b/source/SnapDump-Core/SDStore.class.st
@@ -4,6 +4,18 @@ Class {
 	#category : #'SnapDump-Core'
 }
 
+{ #category : #accessing }
+SDStore class >> mimeTypeFuel [
+
+	^ 'application/X-SnapDump-Fuel'
+]
+
+{ #category : #accessing }
+SDStore class >> mimeTypeStack [
+
+	^ 'application/X-SnapDump-Stack'
+]
+
 { #category : #lookup }
 SDStore class >> withName: aString [
 	^ self subclasses detect: [ :each | each storeName = aString ]

--- a/source/SnapDump-Server-Tests/SDHTTPTests.class.st
+++ b/source/SnapDump-Server-Tests/SDHTTPTests.class.st
@@ -217,10 +217,7 @@ SDHTTPTests >> testSnapshotGetStackTrace [
 	self assert: snapshot snapshotId equals: self dummySnapshotId.
 	stackTrace :=  self store snapshotStackFor: snapshot.
 	self assert: (stackTrace includesSubstring: 'ByteString(Object)>>printStringLimitedTo:
-	Receiver: ''TestString''
-	Arguments and temporary variables: 
-		limit: 	nil
-	Receiver''s instance variables:'
+	Receiver: ''TestString'''
 
 	)
 ]

--- a/source/SnapDump-Server-Tests/SDHTTPTests.class.st
+++ b/source/SnapDump-Server-Tests/SDHTTPTests.class.st
@@ -192,7 +192,7 @@ SDHTTPTests >> testSnapshotGet [
 
 { #category : #tests }
 SDHTTPTests >> testSnapshotGetById [
-	| response snapshot |
+	| response |
 	self createSimpleSnapshot.
 	response := ZnClient new
 		url: self dummySnapshotUrlWithoutProject ;
@@ -202,6 +202,27 @@ SDHTTPTests >> testSnapshotGetById [
 	self assert: response isError.
 	self assert: response code = 404.
 	
+]
+
+{ #category : #tests }
+SDHTTPTests >> testSnapshotGetStackTrace [
+	| response snapshot stackTrace |
+	self createSimpleSnapshot.
+	response := ZnClient new
+		url: self dummySnapshotUrl ;
+		get;
+		response.
+	self assert: response isSuccess.
+	snapshot := (NeoJSONReader on: response contents readStream) nextAs: SDSnapshot .
+	self assert: snapshot snapshotId equals: self dummySnapshotId.
+	stackTrace :=  self store snapshotStackFor: snapshot.
+	self assert: (stackTrace includesSubstring: 'ByteString(Object)>>printStringLimitedTo:
+	Receiver: ''TestString''
+	Arguments and temporary variables: 
+		limit: 	nil
+	Receiver''s instance variables:'
+
+	)
 ]
 
 { #category : #tests }

--- a/source/SnapDump-Server/SDSnapshotCall.class.st
+++ b/source/SnapDump-Server/SDSnapshotCall.class.st
@@ -73,21 +73,19 @@ SDSnapshotCall >> delete [
 
 { #category : #public }
 SDSnapshotCall >> get [
-	| fuelFile json |
+	| snapshot json |
 	json := true.
-	fuelFile := self snapshot.
+	snapshot := self snapshot.
 	request headers 
 		at: 'Accept'
 		ifPresent: [ :header | 
 			(header = 'application/X-SnapDump-Fuel')
-				ifTrue: [ json := false ] ].
-	json 
-		ifTrue: [ 
-			self jsonResponse: fuelFile ]
-		ifFalse: [ 
-			response := ZnResponse ok: ((ZnStreamingEntity 
-				type: ZnMimeType applicationOctetStream length: fuelFile fileSize)
-				stream: fuelFile contentStream ) ] 
+				ifTrue: [ ^ self respondFuel: snapshot].
+			 (header = 'application/X-SnapDump-Stack')
+				ifTrue: [ ^ self respondStack: snapshot].].
+	
+	self jsonResponse: snapshot 
+		
 ]
 
 { #category : #accessing }
@@ -117,6 +115,26 @@ SDSnapshotCall >> put [
 			entity: (ZnStringEntity text: err description) ].
 	self store storeRaw: snapshot contents: request contents.
 	response := ZnResponse ok: (ZnStringEntity text: 'OK')
+]
+
+{ #category : #public }
+SDSnapshotCall >> respondFuel: aFileSnapshot [
+	response := ZnResponse
+		ok:
+			((ZnStreamingEntity
+				type: ZnMimeType applicationOctetStream
+				length: aFileSnapshot fileSize)
+				stream: aFileSnapshot contentStream)
+]
+
+{ #category : #public }
+SDSnapshotCall >> respondStack: aFileSnapshot [
+	response := ZnResponse
+		ok:
+			((ZnStreamingEntity
+				type: ZnMimeType applicationOctetStream
+				length: aFileSnapshot fileSize)
+				stream: aFileSnapshot stackTraceStream )
 ]
 
 { #category : #public }

--- a/source/SnapDump-Server/SDSnapshotCall.class.st
+++ b/source/SnapDump-Server/SDSnapshotCall.class.st
@@ -79,9 +79,9 @@ SDSnapshotCall >> get [
 	request headers 
 		at: 'Accept'
 		ifPresent: [ :header | 
-			(header = 'application/X-SnapDump-Fuel')
+			(header = SDStore mimeTypeFuel)
 				ifTrue: [ ^ self respondFuel: snapshot].
-			 (header = 'application/X-SnapDump-Stack')
+			 (header = SDStore mimeTypeStack)
 				ifTrue: [ ^ self respondStack: snapshot].].
 	
 	self jsonResponse: snapshot 

--- a/source/SnapDump-UI/SDSnapshot.extension.st
+++ b/source/SnapDump-UI/SDSnapshot.extension.st
@@ -20,3 +20,9 @@ SDSnapshot >> gtInspectorSnapshotIn: composite [
 			shouldShowTitle: true)
 
 ]
+
+{ #category : #'*SnapDump-UI' }
+SDSnapshot >> openStackTrace [
+	UIManager default edit: (
+		self store snapshotStackFor: self )
+]

--- a/source/SnapDump-UI/SDSnapshotPresenter.class.st
+++ b/source/SnapDump-UI/SDSnapshotPresenter.class.st
@@ -37,7 +37,16 @@ SDSnapshotPresenter >> initializeWidgets [
 						description: 'Remove Snapshot';
 						icon: (self iconNamed: #smallWarningIcon);
 						action: [ self removeSnapshot
-							  ] ] ].
+							  ] ]. 
+					
+			group
+				addItem: [ :item | 
+					item
+						name: 'Stack trace';
+						description: 'View stack trace';
+						icon: (self iconNamed: #transcript);
+						action: [ snapshot ifNotNil: [snapshot openStackTrace] ] ].		
+					].
 	menu applyTo: self.
 	meta := self newMultiColumnList 
 		displayBlock: [ :key | { key . (Text fromString: (snapshot perform: key) printString) }  ]

--- a/source/SnapDump-UI/SnapDumpUI.class.st
+++ b/source/SnapDump-UI/SnapDumpUI.class.st
@@ -32,7 +32,7 @@ SnapDumpUI class >> defaultSpec [
 SnapDumpUI class >> example [ 
 
 	|port server|
-	port := 9995.
+	port := 9993.
 	server := (Smalltalk at: #SDServer) port: port path: './sd-ui-example' asFileReference.
 	"server start."
 	


### PR DESCRIPTION
Fix proposal for issue #27

Added stackTrace property to Snapshot class.
=> Initialize stackTrace as exception/context gets converted as snapshot
=> store stack stract as an additinal piece of bytes to be read after the fuel context
=> added unit test
=> updated UI in order to provide an additional "Stack trace" button
=> Removed duplication of specific mime types