### PR TITLE
Removed hasSnapshot: and usage of it. A snapshot signature includes a…

### DIFF
--- a/source/SnapDump-Core/SDFilesystemStore.class.st
+++ b/source/SnapDump-Core/SDFilesystemStore.class.st
@@ -200,9 +200,7 @@ SDFilesystemStore >> removeVersion: aVersion [
 
 { #category : #'services - testing' }
 SDFilesystemStore >> shouldReportSnapshot: snapshot [
-	^ (self
-		hasSnapshot: snapshot) not
-		and: [ (self freeSlotsForSnapshot: snapshot) > 0]
+	^  (self freeSlotsForSnapshot: snapshot) > 0
 ]
 
 { #category : #'services - files' }

--- a/source/SnapDump-Handler/SDBasicHTTPStore.class.st
+++ b/source/SnapDump-Handler/SDBasicHTTPStore.class.st
@@ -49,14 +49,6 @@ SDBasicHTTPStore >> freeSlotsForExceptionId: anExceptionId project: aProjectName
 		ifFalse: [ NotFound signal ]
 ]
 
-{ #category : #'services - testing' }
-SDBasicHTTPStore >> hasSnapshot: snapshot [
-	^ (self client
-		url: (self urlForSnapshot: snapshot);
-		head;
-		response) status = 200
-]
-
 { #category : #testing }
 SDBasicHTTPStore >> isSetUp [
 	^ uri notNil
@@ -79,9 +71,7 @@ SDBasicHTTPStore >> printOn: aStream [
 
 { #category : #'services - testing' }
 SDBasicHTTPStore >> shouldReportSnapshot: snapshot [
-	^ (self hasSnapshot: snapshot) not
-		and: [ (self
-				freeSlotsForException: snapshot exception) > 0 ]
+	^ (self freeSlotsForException: snapshot exception) > 0
 ]
 
 { #category : #accessing }


### PR DESCRIPTION
… timestamp which is initialized at object creation which does not mean it is the same snapshot. This way we do not need to use it and need only one http request to inquire if a snapshot should reported