### PR TITLE
Remove the need for beOfType: A handler is now installed whenever the…

### DIFF
--- a/source/SnapDump-Client/SnapDump.extension.st
+++ b/source/SnapDump-Client/SnapDump.extension.st
@@ -3,13 +3,13 @@ Extension { #name : #SnapDump }
 { #category : #'*SnapDump-Client' }
 SnapDump class >> client [
 	^ SDClient new
-		store: self current store;
+		store: self store;
 		yourself
 ]
 
 { #category : #'*SnapDump-Client' }
 SnapDump class >> uri: aUri [
-	^ self current 
+	^ self 
 		store: (SDHTTPStore new uri: aUri asZnUrl);
 		yourself 
 ]

--- a/source/SnapDump-Core/SnapDump.class.st
+++ b/source/SnapDump-Core/SnapDump.class.st
@@ -5,7 +5,8 @@ Class {
 		'store'
 	],
 	#classInstVars : [
-		'current'
+		'current',
+		'handler'
 	],
 	#category : #'SnapDump-Core-Base'
 }
@@ -18,7 +19,7 @@ SnapDump class >> applyConfiguration: aConfig [
 
 { #category : #'as yet unclassified' }
 SnapDump class >> beOfType: aSymbol [
-	current := (self withType: aSymbol) new
+	self deprecated: 'beOfType: is unnecessary now. Just remove calls to this method'
 ]
 
 { #category : #'as yet unclassified' }
@@ -31,30 +32,12 @@ SnapDump class >> configuration [
 
 { #category : #accessing }
 SnapDump class >> current [ 
-	^ current ifNil: [ 
-		current := SDHandler new ]
-]
-
-{ #category : #'as yet unclassified' }
-SnapDump class >> hackUIManager [
-	UIManager compile: 'logError: anError
-		SnapDump current handleException: anError.
-		super logError: anError'
-]
-
-{ #category : #public }
-SnapDump class >> handleException: exception [
-	^ self current handleException: exception 
-]
-
-{ #category : #'as yet unclassified' }
-SnapDump class >> handleSnapshot: aSnapshot [ 
-	^ self current handleSnapshot: aSnapshot 
+	^ current 
 ]
 
 { #category : #accessing }
 SnapDump class >> path: aPathString [
-	^ self current 
+	^ self  
 		store: (SDFilesystemStore new path: aPathString asFileReference);
 		yourself 
 ]
@@ -65,15 +48,25 @@ SnapDump class >> reset [
 ]
 
 { #category : #'as yet unclassified' }
-SnapDump class >> uri: aUri username: aUsername password: aPassword [
-	^ self current store 
-			uri: aUri asZnUrl;
-			username: aUsername password: aPassword
+SnapDump class >> setCurrent: anObject [
+	current := anObject 
 ]
 
-{ #category : #'accessing structure variables' }
-SnapDump class >> withType: aSymbol [
-	^ self allSubclasses detect: [ :each | each type = aSymbol ]
+{ #category : #accessing }
+SnapDump class >> store [
+	^ self current store
+]
+
+{ #category : #accessing }
+SnapDump class >> store: aStore [
+	self current store: aStore
+]
+
+{ #category : #'as yet unclassified' }
+SnapDump class >> uri: aUri username: aUsername password: aPassword [
+	^ self store 
+			uri: aUri asZnUrl;
+			username: aUsername password: aPassword
 ]
 
 { #category : #initialization }

--- a/source/SnapDump-Handler/SnapDump.extension.st
+++ b/source/SnapDump-Handler/SnapDump.extension.st
@@ -2,21 +2,30 @@ Extension { #name : #SnapDump }
 
 { #category : #'*SnapDump-Handler' }
 SnapDump class >> beHandler [
-	| handler |
-	handler := SDHandler new.
-	self setCurrent: handler.
-	^ handler
+	self deprecated: 'handlers are always present now. This call is not necessary anymore'
+]
 
+{ #category : #'*SnapDump-Handler' }
+SnapDump class >> hackUIManager [
+	UIManager compile: 'logError: anError
+		SnapDump current handleException: anError.
+		super logError: anError'
+]
+
+{ #category : #'*SnapDump-Handler' }
+SnapDump class >> handleException: exception [
+	^ self handler handleException: exception 
+]
+
+{ #category : #'*SnapDump-Handler' }
+SnapDump class >> handleSnapshot: aSnapshot [ 
+	^ self handler handleSnapshot: aSnapshot 
 ]
 
 { #category : #'*SnapDump-Handler' }
 SnapDump class >> handler [
-	^ SDHandler new
-		store: self current store;
-		yourself
-]
-
-{ #category : #'*SnapDump-Handler' }
-SnapDump class >> setCurrent: anObject [
-	current := anObject 
+	^ handler ifNil: [  
+		handler := SDHandler new
+		store: self store;
+		yourself ]
 ]

--- a/source/SnapDump-UI/SnapDump.extension.st
+++ b/source/SnapDump-UI/SnapDump.extension.st
@@ -3,6 +3,6 @@ Extension { #name : #SnapDump }
 { #category : #'*SnapDump-UI' }
 SnapDump class >> ui [ 
 	^ SnapDumpUI new 
-		snapDump: (SDClient new store: self current store);
+		snapDump: self client;
 		openWithSpec
 ]

--- a/source/SnapDump-UI/SnapDumpUI.class.st
+++ b/source/SnapDump-UI/SnapDumpUI.class.st
@@ -174,7 +174,7 @@ SnapDumpUI >> subMenu [
 
 	^ MenuPresenter new
 		addGroup: [ :group |
-			SnapDump current projects do: [ :project | 
+			client projects do: [ :project | 
 				group addItem: [ :item |
 					item
 						name: project name;


### PR DESCRIPTION
… handler package is loaded. The client does not use the singleton but caches the client in the ui